### PR TITLE
Add new mock es return type, fixes TS errors

### DIFF
--- a/x-pack/plugins/session_view/public/components/SessionView/index.tsx
+++ b/x-pack/plugins/session_view/public/components/SessionView/index.tsx
@@ -32,6 +32,11 @@ interface SessionViewDeps {
   sessionId: string;
 }
 
+interface MockESReturnData {
+  hits: any[]
+  length: number
+}
+
 /**
  * The main wrapper component for the session view.
  * Currently has mock data and only renders the process_tree component
@@ -80,8 +85,8 @@ export const SessionView = ({ sessionId }: SessionViewDeps) => {
 
   const {
     data: getData
-  } = useQuery(['process-tree', 'process_tree'], () =>
-    http.get(INTERNAL_TEST_ROUTE, {
+  } = useQuery<MockESReturnData, Error>(['process-tree', 'process_tree'], () =>
+    http.get<MockESReturnData>(INTERNAL_TEST_ROUTE, {
       query: {
         index: 'process_tree',
       },

--- a/x-pack/plugins/session_view/public/components/TestPage/index.tsx
+++ b/x-pack/plugins/session_view/public/components/TestPage/index.tsx
@@ -12,7 +12,6 @@ import { jsx } from '@emotion/react';
 import {
   EuiButton,
   EuiFieldText,
-  EuiFlexGrid,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPage,


### PR DESCRIPTION
Fixes a TS lint error when running `yarn kbn bootstrap`

Not the best type defs, I admit, but should unblock running `yarn kbn bootstrap`