### PR TITLE
Session view now loads process events by process.entry.entity_id

### DIFF
--- a/x-pack/plugins/session_view/common/constants.ts
+++ b/x-pack/plugins/session_view/common/constants.ts
@@ -13,6 +13,9 @@ export const BASE_PATH = '/app/sessionView';
 // Internal APIs are recommended to have the INTERNAL- suffix
 export const INTERNAL_TEST_ROUTE = '/internal/session_view/test_route';
 export const INTERNAL_TEST_SAVED_OBJECT_ROUTE = '/internal/session_view/test_saved_object_route';
+export const PROCESS_EVENTS_ROUTE = '/internal/session_view/process_events_route';
+export const RECENT_SESSION_ROUTE = '/internal/session_view/recent_session_route';
 
 export const TEST_SAVED_OBJECT = 'session_view_test_saved_object';
+
 export const PROCESS_EVENTS_PER_PAGE = 2000;

--- a/x-pack/plugins/session_view/common/constants.ts
+++ b/x-pack/plugins/session_view/common/constants.ts
@@ -15,3 +15,4 @@ export const INTERNAL_TEST_ROUTE = '/internal/session_view/test_route';
 export const INTERNAL_TEST_SAVED_OBJECT_ROUTE = '/internal/session_view/test_saved_object_route';
 
 export const TEST_SAVED_OBJECT = 'session_view_test_saved_object';
+export const PROCESS_EVENTS_PER_PAGE = 2000;

--- a/x-pack/plugins/session_view/common/test/mock_data.ts
+++ b/x-pack/plugins/session_view/common/test/mock_data.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 // eslint-disable-next-line @kbn/eslint/no-restricted-paths
-import { Action, ProcessEvent } from '../../public/hooks/use_process_tree';
+import { EventAction, ProcessEvent } from '../../public/hooks/use_process_tree';
 import uuid from 'uuid';
 
 export const getStart = () => {
@@ -14,7 +14,7 @@ export const getStart = () => {
     event: {
       kind: 'event',
       category: 'process',
-      action: Action.exec,
+      action: EventAction.exec,
     },
     process: {
       args: ['bash'],
@@ -111,7 +111,7 @@ export const getEvent = () => {
     event: {
       kind: 'event',
       category: 'process',
-      action: Action.exec,
+      action: EventAction.exec,
     },
     process: {
       args: randomElement.args,
@@ -187,7 +187,7 @@ export const getEnd = () => {
       event: {
         kind: 'event',
         category: 'process',
-        action: Action.exec,
+        action: EventAction.exec,
       },
       process: {
         args: ['df'],
@@ -259,7 +259,7 @@ export const getEnd = () => {
       event: {
         kind: 'event',
         category: 'process',
-        action: Action.fork,
+        action: EventAction.fork,
       },
       process: {
         args: ['df', 'nested'],
@@ -333,7 +333,7 @@ export const getEnd = () => {
       event: {
         kind: 'event',
         category: 'process',
-        action: Action.exec,
+        action: EventAction.exec,
       },
       process: {
         args: ['df', 'nested'],
@@ -407,7 +407,7 @@ export const getEnd = () => {
       event: {
         kind: 'event',
         category: 'process',
-        action: Action.end,
+        action: EventAction.end,
       },
       process: {
         args: ['df', 'nested'],
@@ -487,7 +487,7 @@ export const mockData: ProcessEvent[] = [
     event: {
       kind: 'event',
       category: 'process',
-      action: Action.exec,
+      action: EventAction.exec,
     },
     process: {
       args: ['bash'],
@@ -561,7 +561,7 @@ export const mockData: ProcessEvent[] = [
     event: {
       kind: 'event',
       category: 'process',
-      action: Action.exec,
+      action: EventAction.exec,
     },
     process: {
       args: ['ls', '-l'],
@@ -633,7 +633,7 @@ export const mockData: ProcessEvent[] = [
     event: {
       kind: 'event',
       category: 'process',
-      action: Action.exec,
+      action: EventAction.exec,
     },
     process: {
       args: ['df'],
@@ -705,7 +705,7 @@ export const mockData: ProcessEvent[] = [
     event: {
       kind: 'event',
       category: 'process',
-      action: Action.fork,
+      action: EventAction.fork,
     },
     process: {
       args: ['df', 'nested'],
@@ -779,7 +779,7 @@ export const mockData: ProcessEvent[] = [
     event: {
       kind: 'event',
       category: 'process',
-      action: Action.exec,
+      action: EventAction.exec,
     },
     process: {
       args: ['df', 'nested'],
@@ -853,7 +853,7 @@ export const mockData: ProcessEvent[] = [
     event: {
       kind: 'event',
       category: 'process',
-      action: Action.end,
+      action: EventAction.end,
     },
     process: {
       args: ['df', 'nested'],

--- a/x-pack/plugins/session_view/public/components/ProcessTree/index.tsx
+++ b/x-pack/plugins/session_view/public/components/ProcessTree/index.tsx
@@ -89,17 +89,20 @@ export const ProcessTree = ({
     }
 
     // find the DOM element for the command which is selected by id
-    const processEl = scrollerRef.current.querySelector(`[data-id="${process.id}"]`);
+    const processEl = scrollerRef.current.querySelector<HTMLElement>(`[data-id="${process.id}"]`);
 
     if (processEl) {
       processEl.prepend(selectionAreaEl);
 
-      if (processEl.parentElement) {
-        const rect = processEl.getBoundingClientRect();
-        const elemTop = rect.top;
-        const elemBottom = rect.bottom;
-        const containerHeight = processEl.parentElement.offsetHeight;
-        const isVisible = elemTop >= 0 && elemBottom < containerHeight;
+      const container = processEl.parentElement;
+
+      if (container) {
+        const cTop = container.scrollTop;
+        const cBottom = cTop + container.clientHeight;
+
+        const eTop = processEl.offsetTop;
+        const eBottom = eTop + processEl.clientHeight;
+        const isVisible = eTop >= cTop && eBottom <= cBottom;
 
         if (!isVisible) {
           processEl.scrollIntoView();
@@ -128,7 +131,7 @@ export const ProcessTree = ({
           onProcessSelected={onProcessSelected}
         />
       )}
-      {orphans.forEach((process) => {
+      {orphans.map((process) => {
         return (
           <ProcessTreeNode
             key={process.id}

--- a/x-pack/plugins/session_view/public/components/ProcessTreeNode/index.tsx
+++ b/x-pack/plugins/session_view/public/components/ProcessTreeNode/index.tsx
@@ -11,7 +11,7 @@
  *2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useRef, useLayoutEffect, useState, useEffect, MouseEvent } from 'react';
+import React, { useMemo, useRef, useLayoutEffect, useState, useEffect, MouseEvent } from 'react';
 import { EuiButton, EuiIcon } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n/react';
 import { Process } from '../../hooks/use_process_tree';
@@ -47,7 +47,7 @@ export function ProcessTreeNode({
   }, [isSessionLeader, process.autoExpand]);
 
   useLayoutEffect(() => {
-    if (searchMatched !== null && textRef && textRef.current) {
+    if (searchMatched !== null && textRef.current) {
       const regex = new RegExp(searchMatched);
 
       const text = textRef.current.innerText;
@@ -59,13 +59,19 @@ export function ProcessTreeNode({
     }
   }, [searchMatched]);
 
-  const event = process.getDetails();
+  const processDetails = useMemo(() => {
+    return process.getDetails();
+  }, [process.events.length]);
 
-  if (!event) {
+  const hasExec = useMemo(() => {
+    return process.hasExec();
+  }, [process.events.length]);
+
+  if (!processDetails) {
     return null;
   }
 
-  const { interactive } = event.process;
+  const { interactive } = processDetails.process;
 
   const renderChildren = () => {
     const { children } = process;
@@ -132,7 +138,7 @@ export function ProcessTreeNode({
       working_directory: workingDirectory,
       exit_code: exitCode,
     } = process.getDetails().process;
-    if (process.hasExec()) {
+    if (hasExec) {
       return (
         <span ref={textRef}>
           <span css={styles.workingDir}>{workingDirectory}</span>&nbsp;
@@ -154,7 +160,7 @@ export function ProcessTreeNode({
     return (
       <span>
         {process.isUserEntered() && <EuiIcon css={styles.userEnteredIcon} type="user" />}
-        <EuiIcon type={process.hasExec() ? 'console' : 'branch'} /> {template()}
+        <EuiIcon type={hasExec ? 'console' : 'branch'} /> {template()}
         {isOrphan ? '(orphaned)' : ''}
       </span>
     );

--- a/x-pack/plugins/session_view/public/components/SessionView/index.tsx
+++ b/x-pack/plugins/session_view/public/components/SessionView/index.tsx
@@ -12,7 +12,7 @@ import { CoreStart } from '../../../../../../src/core/public';
 import { ProcessTree } from '../ProcessTree';
 import { Process, ProcessEvent } from '../../hooks/use_process_tree';
 import { useStyles } from './styles';
-import { INTERNAL_TEST_ROUTE } from '../../../common/constants';
+import { PROCESS_EVENTS_ROUTE } from '../../../common/constants';
 
 interface SessionViewDeps {
   // the root node of the process tree to render. e.g process.entry.entity_id or process.session.entity_id
@@ -59,7 +59,7 @@ export const SessionView = ({ sessionEntityId, height }: SessionViewDeps) => {
   const { data: getData } = useQuery<ProcessEventResults, Error>(
     ['process-tree', 'process_tree'],
     () =>
-      http.get<ProcessEventResults>(INTERNAL_TEST_ROUTE, {
+      http.get<ProcessEventResults>(PROCESS_EVENTS_ROUTE, {
         query: {
           indexes: ['cmd*', '.siem-signals-*'],
           sessionEntityId

--- a/x-pack/plugins/session_view/public/components/SessionView/index.tsx
+++ b/x-pack/plugins/session_view/public/components/SessionView/index.tsx
@@ -5,58 +5,42 @@
  * 2.0.
  */
 import React, { useState, useEffect } from 'react';
+import { useQuery } from 'react-query';
+import { EuiSearchBar, EuiSearchBarOnChangeArgs, EuiEmptyPrompt } from '@elastic/eui';
 import { useKibana } from '../../../../../../src/plugins/kibana_react/public';
 import { CoreStart } from '../../../../../../src/core/public';
-import { useQuery, useMutation } from 'react-query';
-import { 
-  EuiSearchBar, 
-  EuiSearchBarOnChangeArgs, 
-  EuiButton, 
-  EuiPage, 
-  EuiPageContent,
-  EuiPageHeader,
-  EuiSpacer,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiEmptyPrompt
-} from '@elastic/eui';
 import { ProcessTree } from '../ProcessTree';
-import { getStart, getEnd, getEvent } from '../../../common/test/mock_data';
-import { Process } from '../../hooks/use_process_tree';
-
-import {
-  INTERNAL_TEST_ROUTE,
-} from '../../../common/constants';
+import { Process, ProcessEvent } from '../../hooks/use_process_tree';
+import { useStyles } from './styles';
+import { INTERNAL_TEST_ROUTE } from '../../../common/constants';
 
 interface SessionViewDeps {
-  sessionId: string;
+  // the root node of the process tree to render. e.g process.entry.entity_id or process.session.entity_id
+  sessionEntityId: string;
+  height?: number;
 }
 
-interface MockESReturnData {
-  hits: any[]
-  length: number
+interface ProcessEventResults {
+  hits: any[];
+  length: number;
 }
 
 /**
  * The main wrapper component for the session view.
- * Currently has mock data and only renders the process_tree component
  * TODO:
- * - React query, fetching and paging events by sessionId
  * - Details panel
  * - Fullscreen toggle
  * - Search results navigation
  * - Settings menu (needs design)
  */
-export const SessionView = ({ sessionId }: SessionViewDeps) => {
+export const SessionView = ({ sessionEntityId, height }: SessionViewDeps) => {
   const [searchQuery, setSearchQuery] = useState('');
-  const [data, setData] = useState<any[]>([]);
+  const [data, setData] = useState<ProcessEvent[]>([]);
   const [selectedProcess, setSelectedProcess] = useState<Process | null>(null);
 
   const { http } = useKibana<CoreStart>().services;
 
-  const processTreeCSS = `
-    height: 300px;
-  `;
+  const styles = useStyles({ height });
 
   const onProcessSelected = (process: Process) => {
     if (selectedProcess !== process) {
@@ -72,52 +56,16 @@ export const SessionView = ({ sessionId }: SessionViewDeps) => {
     }
   };
 
-  const {
-    mutate
-  } = useMutation((insertData) => {
-    return http.put(INTERNAL_TEST_ROUTE, { 
-      body: JSON.stringify({ 
-        index: 'process_tree',
-        data: JSON.stringify(insertData)
+  const { data: getData } = useQuery<ProcessEventResults, Error>(
+    ['process-tree', 'process_tree'],
+    () =>
+      http.get<ProcessEventResults>(INTERNAL_TEST_ROUTE, {
+        query: {
+          indexes: ['cmd*', '.siem-signals-*'],
+          sessionEntityId
+        },
       })
-    });
-  });
-
-  const {
-    data: getData
-  } = useQuery<MockESReturnData, Error>(['process-tree', 'process_tree'], () =>
-    http.get<MockESReturnData>(INTERNAL_TEST_ROUTE, {
-      query: {
-        index: 'process_tree',
-      },
-    })
   );
-
-  const {
-    mutate: deleteMutate
-  } = useMutation((insertData) => {
-    return http.delete(INTERNAL_TEST_ROUTE, { 
-      body: JSON.stringify({ 
-        index: 'process_tree'
-      })
-    });
-  });
-  
-  const handleMutate = (insertData: any) => {
-    mutate(insertData, {
-      onSuccess: () => {
-        setData([...data, ...insertData])
-      }
-    });
-  }
-
-  const handleDelete = () => {
-    deleteMutate(undefined, {
-      onSuccess: () => {
-        setData([]);
-      }
-    })
-  }
 
   useEffect(() => {
     if (!getData) {
@@ -128,83 +76,35 @@ export const SessionView = ({ sessionId }: SessionViewDeps) => {
       return;
     }
 
-    setData(getData.hits.map((event: any) => event._source));
+    setData(getData.hits.map((event: any) => event._source as ProcessEvent));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getData]);
 
   const renderNoData = () => {
-    if (data.length) {
-      return null;
-    }
     return (
-      <EuiEmptyPrompt 
+      <EuiEmptyPrompt
         title={<h2>No data to render</h2>}
-        body={
-          <p>
-            Please start by adding some data using the bottons below
-          </p>
-        }
+        body={<p>No process events found for this query.</p>}
       />
-    )
-  }
+    );
+  };
 
-  const renderInsertButtons = () => {
-    return (
-      <EuiFlexGroup justifyContent="spaceAround">
-        <EuiFlexItem>
-          <EuiButton onClick={() => handleMutate(getStart())}>
-            Insert Session Start
-          </EuiButton>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiButton onClick={() => handleMutate(getEvent())}>
-            Insert Command
-          </EuiButton>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiButton onClick={() => handleMutate(getEnd())}>
-            Insert End
-          </EuiButton>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiButton onClick={handleDelete}>
-            Delete Data
-          </EuiButton>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    )
+  if (!data.length) {
+    return renderNoData();
   }
 
   return (
-    <EuiPage>
-      <EuiPageContent>
-        <EuiPageHeader 
-          pageTitle="Process Tree"
-          iconType="logoKibana"
-          description={
-            `Below is an example of the process tree, demonstrating data fetching patterns and data rendering.
-            Please start by adding some mock data
-            `
-          }
+    <>
+      <EuiSearchBar query={searchQuery} onChange={onSearch} />
+      <div css={styles.processTree}>
+        <ProcessTree
+          sessionEntityId={sessionEntityId}
+          forward={data}
+          searchQuery={searchQuery}
+          selectedProcess={selectedProcess}
+          onProcessSelected={onProcessSelected}
         />
-        <EuiSpacer />
-        {renderNoData()}
-        {!!data.length &&
-          <>
-            <EuiSearchBar query={searchQuery} onChange={onSearch} />
-            <div css={processTreeCSS}>
-              <ProcessTree
-                sessionId={sessionId}
-                forward={data}
-                searchQuery={searchQuery}
-                selectedProcess={selectedProcess}
-                onProcessSelected={onProcessSelected}
-              />
-            </div>  
-          </>
-        }
-        <EuiSpacer />
-        {renderInsertButtons()}
-      </EuiPageContent>
-    </EuiPage>
+      </div>
+    </>
   );
 };

--- a/x-pack/plugins/session_view/public/components/SessionView/styles.ts
+++ b/x-pack/plugins/session_view/public/components/SessionView/styles.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+// import { useEuiTheme } from '@elastic/eui';
+import { CSSObject } from '@emotion/react';
+
+interface StylesDeps {
+  height: number | undefined;
+}
+
+export const useStyles = ({ height = 500 }: StylesDeps) => {
+  // const { euiTheme } = useEuiTheme();
+
+  const cached = useMemo(() => {
+    // const { colors, border, font, size } = euiTheme;
+
+    const processTree: CSSObject = {
+      height: height + 'px',
+    };
+
+    return {
+      processTree,
+    };
+  }, []);
+
+  return cached;
+};

--- a/x-pack/plugins/session_view/public/components/SessionViewPage/index.tsx
+++ b/x-pack/plugins/session_view/public/components/SessionViewPage/index.tsx
@@ -1,13 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
 import React from 'react';
 import { RouteComponentProps } from 'react-router-dom';
-
+import { EuiPage, EuiPageContent, EuiPageHeader, EuiSpacer } from '@elastic/eui';
 import { useKibana } from '../../../../../../src/plugins/kibana_react/public';
 import { CoreStart } from '../../../../../../src/core/public';
 import { BASE_PATH } from '../../../common/constants';
 
 import { SessionView } from '../SessionView';
 
-const testSessionId = '4321';
+// TODO: sourced from local test data. eventually, session list table will pass in process.entry.entity_id
+const testRootEntityId = '44f4dece-d963-51c9-bfa3-875c0c8e1ec3';
 
 export const SessionViewPage = (props: RouteComponentProps) => {
   const { chrome, http } = useKibana<CoreStart>().services;
@@ -20,8 +28,19 @@ export const SessionViewPage = (props: RouteComponentProps) => {
   chrome.docTitle.change('Process Tree');
 
   return (
-    <div>
-      <SessionView sessionId={testSessionId} />
-    </div>
+    <EuiPage>
+      <EuiPageContent>
+        <EuiPageHeader
+          pageTitle="Process Tree"
+          iconType="logoKibana"
+          description={`Below is an example of the process tree, demonstrating data fetching patterns and data rendering.
+            Please start by adding some mock data
+            `}
+        />
+        <EuiSpacer />
+        <SessionView sessionEntityId={testRootEntityId} />
+        <EuiSpacer />
+      </EuiPageContent>
+    </EuiPage>
   );
 };

--- a/x-pack/plugins/session_view/public/components/SessionViewPage/index.tsx
+++ b/x-pack/plugins/session_view/public/components/SessionViewPage/index.tsx
@@ -63,7 +63,7 @@ export const SessionViewPage = (props: RouteComponentProps) => {
             `}
         />
         <EuiSpacer />
-        <SessionView key={sessionEntityId} sessionEntityId={sessionEntityId} />
+        {sessionEntityId && <SessionView sessionEntityId={sessionEntityId} />}
         <EuiSpacer />
       </EuiPageContent>
     </EuiPage>

--- a/x-pack/plugins/session_view/public/components/TestPage/index.tsx
+++ b/x-pack/plugins/session_view/public/components/TestPage/index.tsx
@@ -63,29 +63,37 @@ export const TestPage = (props: RouteComponentProps) => {
     mutate,
     isLoading,
     data: putData,
-  } = useMutation(() => {
-    return http.put(INTERNAL_TEST_ROUTE, { 
-      body: JSON.stringify({ 
-        index: indexName,
-        data: JSON.stringify([{ message }])
-      }), 
-    });
-  }, { onSuccess: () => {
-    notifications.toasts.addSuccess('Data Added!');
-  }});
+  } = useMutation(
+    () => {
+      return http.put(INTERNAL_TEST_ROUTE, {
+        body: JSON.stringify({
+          index: indexName,
+          data: JSON.stringify([{ message }]),
+        }),
+      });
+    },
+    {
+      onSuccess: () => {
+        notifications.toasts.addSuccess('Data Added!');
+      },
+    }
+  );
 
   // An example of using useQuery to hit an internal endpoint via mutation (PUT)
-  const {
-    mutate: deleteMutate,
-  } = useMutation(() => {
-    return http.delete(INTERNAL_TEST_ROUTE, { 
-      body: JSON.stringify({ 
-        index: indexName
-      })
-    });
-  }, { onSuccess: () => {
-    notifications.toasts.addSuccess('Data Deleted!');
-  }});
+  const { mutate: deleteMutate } = useMutation(
+    () => {
+      return http.delete(INTERNAL_TEST_ROUTE, {
+        body: JSON.stringify({
+          index: indexName,
+        }),
+      });
+    },
+    {
+      onSuccess: () => {
+        notifications.toasts.addSuccess('Data Deleted!');
+      },
+    }
+  );
 
   const handleInsertData = () => {
     mutate();
@@ -136,14 +144,12 @@ export const TestPage = (props: RouteComponentProps) => {
   return (
     <EuiPage>
       <EuiPageContent data-test-subj="sessionViewTestPage">
-        <EuiPageHeader 
+        <EuiPageHeader
           pageTitle="Plugin POC"
           iconType="logoKibana"
-          description={
-            `Below is a POC of a Kibana plugin, demonstrating data fetching patterns and data rendering.
+          description={`Below is a POC of a Kibana plugin, demonstrating data fetching patterns and data rendering.
             Please start by adding some mock data
-            `
-          }
+          `}
         />
         <EuiSpacer />
         <EuiFlexGroup>
@@ -208,20 +214,12 @@ export const TestPage = (props: RouteComponentProps) => {
             <div>
               put network data:
               <EuiSpacer />
-              {SOisLoading ? (
-                <div>Loading!</div>
-              ) : (
-                <pre>{JSON.stringify(SOputData, null, 2)}</pre>
-              )}
+              {SOisLoading ? <div>Loading!</div> : <pre>{JSON.stringify(SOputData, null, 2)}</pre>}
             </div>
             <div>
               get network data:
               <EuiSpacer />
-              {SOisFetching ? (
-                <div>Loading!</div>
-              ) : (
-                <pre>{JSON.stringify(SOgetData, null, 2)}</pre>
-              )}
+              {SOisFetching ? <div>Loading!</div> : <pre>{JSON.stringify(SOgetData, null, 2)}</pre>}
             </div>
             <EuiSpacer />
           </EuiFlexItem>

--- a/x-pack/plugins/session_view/server/routes/index.ts
+++ b/x-pack/plugins/session_view/server/routes/index.ts
@@ -8,8 +8,12 @@
 import { IRouter } from '../../../../../src/core/server';
 import { registerTestRoute } from './test_route';
 import { registerTestSavedObjectsRoute } from './test_saved_objects_route';
+import { registerProcessEventsRoute } from './process_events_route';
+import { registerRecentSessionRoute } from './recent_session_route';
 
 export const registerRoutes = (router: IRouter) => {
   registerTestRoute(router);
   registerTestSavedObjectsRoute(router);
+  registerProcessEventsRoute(router);
+  registerRecentSessionRoute(router);
 };

--- a/x-pack/plugins/session_view/server/routes/process_events_route.ts
+++ b/x-pack/plugins/session_view/server/routes/process_events_route.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { schema } from '@kbn/config-schema';
+import { IRouter } from '../../../../../src/core/server';
+import { PROCESS_EVENTS_ROUTE, PROCESS_EVENTS_PER_PAGE } from '../../common/constants';
+
+export const registerProcessEventsRoute = (router: IRouter) => {
+  router.get(
+    {
+      path: PROCESS_EVENTS_ROUTE,
+      validate: {
+        query: schema.object({
+          indexes: schema.maybe(schema.arrayOf(schema.string())),
+          sessionEntityId: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      const client = context.core.elasticsearch.client.asCurrentUser;
+
+      const { indexes, sessionEntityId } = request.query;
+
+      const search = await client.search({
+        index: indexes,
+        query: {
+          match: {
+            'process.entry.entity_id': sessionEntityId,
+          },
+        },
+        size: PROCESS_EVENTS_PER_PAGE,
+        sort: '@timestamp',
+      });
+
+      return response.ok({ body: search.body.hits });
+    }
+  );
+};

--- a/x-pack/plugins/session_view/server/routes/recent_session_route.ts
+++ b/x-pack/plugins/session_view/server/routes/recent_session_route.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { schema } from '@kbn/config-schema';
+import { IRouter } from '../../../../../src/core/server';
+import { RECENT_SESSION_ROUTE } from '../../common/constants';
+
+export const registerRecentSessionRoute = (router: IRouter) => {
+  router.get(
+    {
+      path: RECENT_SESSION_ROUTE,
+      validate: {
+        query: schema.object({
+          indexes: schema.maybe(schema.arrayOf(schema.string())),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      const client = context.core.elasticsearch.client.asCurrentUser;
+
+      const { indexes } = request.query;
+
+      const search = await client.search({
+        index: indexes,
+        query: {
+          match: {
+            'process.entry.interactive': true,
+          },
+        },
+        size: 1
+      });
+
+      return response.ok({ body: search.body.hits });
+    }
+  );
+};

--- a/x-pack/plugins/session_view/server/routes/test_route.ts
+++ b/x-pack/plugins/session_view/server/routes/test_route.ts
@@ -4,10 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import { schema } from '@kbn/config-schema';
 import uuid from 'uuid';
 import { IRouter } from '../../../../../src/core/server';
-import { INTERNAL_TEST_ROUTE, PROCESS_EVENTS_PER_PAGE } from '../../common/constants';
+import { INTERNAL_TEST_ROUTE } from '../../common/constants';
 
 export const registerTestRoute = (router: IRouter) => {
   router.get(
@@ -15,8 +16,7 @@ export const registerTestRoute = (router: IRouter) => {
       path: INTERNAL_TEST_ROUTE,
       validate: {
         query: schema.object({
-          indexes: schema.maybe(schema.arrayOf(schema.string())),
-          sessionEntityId: schema.maybe(schema.string()),
+          index: schema.maybe(schema.string()),
         }),
       },
     },
@@ -24,17 +24,10 @@ export const registerTestRoute = (router: IRouter) => {
       // TODO (Jiawei & Paulo): Evaluate saved objects & ES client
       const client = context.core.elasticsearch.client.asCurrentUser;
 
-      const { indexes, sessionEntityId } = request.query;
+      const { index } = request.query;
 
       const search = await client.search({
-        index: indexes,
-        query: {
-          match: {
-            'process.entry.entity_id': sessionEntityId,
-          },
-        },
-        size: PROCESS_EVENTS_PER_PAGE,
-        sort: '@timestamp',
+        index: [`${index}`]
       });
 
       return response.ok({ body: search.body.hits });
@@ -66,7 +59,7 @@ export const registerTestRoute = (router: IRouter) => {
             timestamp: new Date().toISOString(),
           },
         });
-      });
+      })
 
       await Promise.all(requests);
 
@@ -83,7 +76,7 @@ export const registerTestRoute = (router: IRouter) => {
       path: INTERNAL_TEST_ROUTE,
       validate: {
         body: schema.object({
-          index: schema.string(),
+          index: schema.string()
         }),
       },
     },
@@ -91,18 +84,18 @@ export const registerTestRoute = (router: IRouter) => {
       const { index } = request.body;
       const client = context.core.elasticsearch.client.asCurrentUser;
 
-      await client.deleteByQuery({
+      await client.deleteByQuery({ 
         index,
         body: {
           query: { match_all: {} },
         },
       });
-
+      
       return response.ok({
         body: {
           message: 'ok!',
         },
       });
-    }
-  );
+    },
+  )
 };


### PR DESCRIPTION
This will allow us to use EventConverter to get real data into ES and have it show up in session_view.

- session_view_page (test page) component will now grab the process.entry.entity_id of the most recent event and pass to session_view to load. temporary until we have a sessions table.
- UX treatment for processes with no exec (fork only)
- session view now loads events for a given sessionEntityId
- Other refactoring cleanup
- temporary handling of orphans (not final) 

TODO:
- alerts event/schema handling. initial alerts expandable UX placeholder.