### PR TITLE
Separate alert events into alert detail in detail panel

### DIFF
--- a/x-pack/plugins/session_view/public/components/SessionView/index.tsx
+++ b/x-pack/plugins/session_view/public/components/SessionView/index.tsx
@@ -158,7 +158,7 @@ export const SessionView = ({ sessionEntityId, height }: SessionViewDeps) => {
   };
 
   const renderSessionViewDetailPanel = () => {
-    if (selectedProcess && isDetailOpen) {
+    if (isDetailOpen) {
       return (
         <SessionViewDetailPanel
           isDetailMounted={isDetailMounted}


### PR DESCRIPTION
Signal events (alerts) were put together under command detail before in the session view detail panel. they are now under the alert detail section in the detail panel

![image](https://user-images.githubusercontent.com/16872649/143298901-ac773f30-0b3b-4af6-9ff8-7b49a4878ecd.png)
