### PR TITLE
Fix process tree child processes loop

### DIFF
--- a/x-pack/plugins/session_view/public/hooks/use_process_tree.ts
+++ b/x-pack/plugins/session_view/public/hooks/use_process_tree.ts
@@ -26,6 +26,13 @@ export enum EventAction {
   output = 'output',
 }
 
+interface EventActionPartition {
+  fork: ProcessEvent[];
+  exec: ProcessEvent[];
+  exit: ProcessEvent[];
+  output: ProcessEvent[];
+}
+
 interface User {
   id: string;
   name: string;
@@ -160,22 +167,31 @@ class ProcessImpl implements Process {
   }
 
   getDetails() {
-    const execsForks = this.events.filter(
-      ({ event }) => event.action === EventAction.exec || event.action === EventAction.fork
+    const eventsPartition = this.events.reduce(
+      (currEventsParition, processEvent) => {
+        currEventsParition[processEvent.event.action]?.push(processEvent);
+        return currEventsParition;
+      },
+      Object.values(EventAction).reduce((currActions, action) => {
+        currActions[action] = [] as ProcessEvent[];
+        return currActions;
+      }, {} as EventActionPartition)
     );
 
-    const execs = execsForks.filter(({ event }) => event.action === EventAction.exec);
-
-    if (execs.length) {
-      return execs[execs.length - 1];
-    }
-
-    if (execsForks.length === 0) {
+    if (!(eventsPartition.exec.length || eventsPartition.fork.length)) {
       // eslint-disable-next-line no-debugger
       debugger;
     }
 
-    return execsForks[execsForks.length - 1];
+    if (eventsPartition.exec.length) {
+      return eventsPartition.exec[eventsPartition.exec.length - 1];
+    }
+
+    if (eventsPartition.fork.length) {
+      return eventsPartition.fork[eventsPartition.fork.length - 1];
+    }
+
+    return {} as ProcessEvent;
   }
 
   getOutput() {

--- a/x-pack/plugins/session_view/public/hooks/use_process_tree.ts
+++ b/x-pack/plugins/session_view/public/hooks/use_process_tree.ts
@@ -164,6 +164,12 @@ class ProcessImpl implements Process {
       ({ event }) => event.action === EventAction.exec || event.action === EventAction.fork
     );
 
+    const execs = execsForks.filter(({ event }) => event.action === EventAction.exec);
+
+    if (execs.length) {
+      return execs[execs.length - 1];
+    }
+
     if (execsForks.length === 0) {
       // eslint-disable-next-line no-debugger
       debugger;
@@ -249,7 +255,7 @@ export const useProcessTree = ({
       if (parentProcess) {
         process.parent = parentProcess; // handy for recursive operations (like auto expand)
 
-        if (!parentProcess.children.includes(process)) {
+        if (!parentProcess.children.includes(process) && parentProcess.id !== process.id) {
           if (backwardDirection) {
             parentProcess.children.unshift(process);
           } else {


### PR DESCRIPTION
Fix infinite child process loop for session leaders

Also added a fix to avoid assuming execs will come after forks in `getDetails()`