### PR TITLE
Fixing i18n imports

### DIFF
--- a/x-pack/plugins/session_view/public/application.tsx
+++ b/x-pack/plugins/session_view/public/application.tsx
@@ -10,7 +10,7 @@ import ReactDOM from 'react-dom';
 import { Router } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
-import { I18nProvider } from '@kbn/i18n/react';
+import { I18nProvider } from '@kbn/i18n-react';
 import { EuiErrorBoundary } from '@elastic/eui';
 import type { AppMountParameters, CoreStart } from 'kibana/public';
 import { KibanaContextProvider } from '../../../../src/plugins/kibana_react/public';

--- a/x-pack/plugins/session_view/public/components/ProcessTreeAlerts/index.tsx
+++ b/x-pack/plugins/session_view/public/components/ProcessTreeAlerts/index.tsx
@@ -14,7 +14,7 @@ import {
   EuiHorizontalRule,
   EuiSpacer,
 } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n/react';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { useStyles } from './styles';
 import { ProcessEvent } from '../../../common/types/process_tree';
 import { useKibana } from '../../../../../../src/plugins/kibana_react/public';

--- a/x-pack/plugins/session_view/public/components/ProcessTreeNode/index.tsx
+++ b/x-pack/plugins/session_view/public/components/ProcessTreeNode/index.tsx
@@ -13,7 +13,7 @@
  */
 import React, { useMemo, useRef, useLayoutEffect, useState, useEffect, MouseEvent } from 'react';
 import { EuiButton, EuiIcon } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n/react';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { Process } from '../../../common/types/process_tree';
 import { useStyles, ButtonType } from './styles';
 import { ProcessTreeAlerts } from '../ProcessTreeAlerts';

--- a/x-pack/plugins/session_view/public/components/SessionView/index.tsx
+++ b/x-pack/plugins/session_view/public/components/SessionView/index.tsx
@@ -13,7 +13,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
 } from '@elastic/eui';
-import { FormattedMessage } from '@kbn/i18n/react';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { SectionLoading } from '../../shared_imports';
 import { ProcessTree } from '../ProcessTree';
 import { Process } from '../../../common/types/process_tree';

--- a/x-pack/plugins/session_view/public/components/SessionViewDetailPanel/index.tsx
+++ b/x-pack/plugins/session_view/public/components/SessionViewDetailPanel/index.tsx
@@ -7,7 +7,7 @@
 import React, { useState, useEffect, ReactNode } from 'react';
 import MonacoEditor from 'react-monaco-editor';
 import { partition } from 'lodash';
-import { FormattedMessage } from '@kbn/i18n/react';
+import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiSpacer, EuiSplitPanel, EuiTitle, EuiTabs, EuiTab } from '@elastic/eui';
 import { EventKind, Process } from '../../../common/types/process_tree';
 import { useStyles } from './styles';

--- a/x-pack/plugins/session_view/public/test/index.tsx
+++ b/x-pack/plugins/session_view/public/test/index.tsx
@@ -12,7 +12,7 @@ import { QueryClient, QueryClientProvider, setLogger } from 'react-query';
 import { Router } from 'react-router-dom';
 import { History } from 'history';
 import useObservable from 'react-use/lib/useObservable';
-import { I18nProvider } from '@kbn/i18n/react';
+import { I18nProvider } from '@kbn/i18n-react';
 import { CoreStart } from 'src/core/public';
 import { coreMock } from 'src/core/public/mocks';
 import { KibanaContextProvider } from 'src/plugins/kibana_react/public';


### PR DESCRIPTION
### What

Fixing `i18n` imports that were causing errors after merging with Elastic's kibana main branch.

### Why

`@kbn/i18n/react` was replaced for `@kbn/i18n-react` in [this PR](https://github.com/elastic/kibana/pull/119256)