### PR TITLE
ProcessTree tests

### DIFF
--- a/x-pack/plugins/session_view/common/mocks/constants/session_view_process.mock.ts
+++ b/x-pack/plugins/session_view/common/mocks/constants/session_view_process.mock.ts
@@ -232,7 +232,7 @@ export const mockEvents = [
       kind: EventKind.event,
     },
   },
-];
+] as ProcessEvent[];
 
 export const mockAlerts = [
   {

--- a/x-pack/plugins/session_view/public/components/ProcessTree/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/ProcessTree/index.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { mockEvents } from '../../../common/mocks/constants/session_view_process.mock';
+import { AppContextTestRender, createAppRootMockRenderer } from '../../test';
+import { ProcessTree } from './index';
+
+describe('ProcessTree component', () => {
+  let render: () => ReturnType<AppContextTestRender['render']>;
+  let renderResult: ReturnType<typeof render>;
+  let mockedContext: AppContextTestRender;
+
+  beforeEach(() => {
+    mockedContext = createAppRootMockRenderer();
+  });
+
+  describe('When ProcessTree is mounted', () => {
+    it('should render given a valid sessionEntityId and Forward data', () => {
+      renderResult = mockedContext.render(<ProcessTree sessionEntityId="1" forward={mockEvents} />);
+      expect(renderResult.queryByTestId('sessionViewProcessTree')).toBeTruthy();
+      expect(renderResult.queryByTestId('processTreeNode')).toBeTruthy();
+    });
+    describe('Orphaned childrens', () => {
+      const orphanedProcess = {
+        ...mockEvents[0],
+        process: {
+          ...mockEvents[0].process,
+          parent: {
+            ...mockEvents[0].process.parent,
+            entity_id: 'orphaned-id',
+          },
+        },
+      } as unknown as typeof mockEvents[0];
+
+      it('should render orphaned childrens if hideOrphans set to false', () => {
+        renderResult = mockedContext.render(
+          <ProcessTree
+            sessionEntityId="1"
+            forward={mockEvents.concat(orphanedProcess)}
+            hideOrphans={false}
+          />
+        );
+
+        expect(renderResult.queryByText(/orphaned/i)).toBeTruthy();
+      });
+      it('should not render orphaned childrens if hideOrphans set to true', () => {
+        renderResult = mockedContext.render(
+          <ProcessTree
+            sessionEntityId="1"
+            forward={mockEvents.concat(orphanedProcess)}
+            hideOrphans={true}
+          />
+        );
+
+        expect(renderResult.queryByText(/orphaned/i)).toBeFalsy();
+      });
+    });
+  });
+});

--- a/x-pack/plugins/session_view/public/components/ProcessTree/index.tsx
+++ b/x-pack/plugins/session_view/public/components/ProcessTree/index.tsx
@@ -11,8 +11,6 @@ import { ProcessEvent, Process } from '../../../common/types/process_tree';
 import { useScroll } from '../../hooks/use_scroll';
 import { useStyles } from './styles';
 
-const HIDE_ORPHANS = true;
-
 interface ProcessTreeDeps {
   // process.entity_id to act as root node (typically a session (or entry session) leader).
   sessionEntityId: string;
@@ -27,8 +25,9 @@ interface ProcessTreeDeps {
   searchQuery?: string;
 
   // currently selected process
-  selectedProcess: Process | null;
-  onProcessSelected(process: Process): void;
+  selectedProcess?: Process | null;
+  onProcessSelected?: (process: Process) => void;
+  hideOrphans?: boolean;
 }
 
 export const ProcessTree = ({
@@ -38,6 +37,7 @@ export const ProcessTree = ({
   searchQuery,
   selectedProcess,
   onProcessSelected,
+  hideOrphans = true,
 }: ProcessTreeDeps) => {
   const styles = useStyles();
 
@@ -126,7 +126,7 @@ export const ProcessTree = ({
   console.log(searchResults);
 
   const renderOrphans = () => {
-    if (!HIDE_ORPHANS) {
+    if (!hideOrphans) {
       return orphans.map((process) => {
         return (
           <ProcessTreeNode


### PR DESCRIPTION
# What

- Adding tests for `<ProcessTree/>` component
- updated `HIDE_ORPHANS` constant to a `<ProcessTree/>` prop  

![image](https://user-images.githubusercontent.com/19270322/146406595-f3555c06-efbe-4722-bec6-2678c4457a22.png)
