### PR TITLE
Update interfaces to match ECS

### DIFF
--- a/x-pack/plugins/session_view/common/types/process_tree/index.ts
+++ b/x-pack/plugins/session_view/common/types/process_tree/index.ts
@@ -60,7 +60,7 @@ export interface ProcessFields {
 }
 
 export interface ProcessSelf extends ProcessFields {
-  parent: ProcessSelf;
+  parent: ProcessFields;
   session_leader: ProcessFields;
   entry_leader: ProcessFields;
   group_leader: ProcessFields;

--- a/x-pack/plugins/session_view/common/types/process_tree/index.ts
+++ b/x-pack/plugins/session_view/common/types/process_tree/index.ts
@@ -33,27 +33,37 @@ export interface ProcessEventResults {
   events: any[];
 }
 
+export interface Teletype {
+  descriptor: number;
+  type: string;
+  char_device: {
+    major: number;
+    minor: number;
+  };
+}
+
 export interface ProcessFields {
+  entity_id: string;
   args: string[];
   args_count: number;
-  entity_id: string;
+  command_line: string;
   executable: string;
-  interactive: boolean;
   name: string;
+  interactive: boolean;
   working_directory: string;
   pid: number;
-  pgid: number;
-  user: User;
   start: Date;
   end?: Date;
+  user: User;
   exit_code?: number;
+  tty: Teletype;
 }
 
 export interface ProcessSelf extends ProcessFields {
-  parent: ProcessFields;
-  session: ProcessFields;
-  entry: ProcessFields;
-  last_user_entered?: ProcessFields;
+  parent: ProcessSelf;
+  session_leader: ProcessFields;
+  entry_leader: ProcessFields;
+  group_leader: ProcessFields;
 }
 
 export interface ProcessEventHost {
@@ -69,7 +79,6 @@ export interface ProcessEventHost {
     kernel: string;
     name: string;
     platform: string;
-    type: string;
     version: string;
   };
 }

--- a/x-pack/plugins/session_view/public/components/ProcessTree/hooks.ts
+++ b/x-pack/plugins/session_view/public/components/ProcessTree/hooks.ts
@@ -121,9 +121,9 @@ export class ProcessImpl implements Process {
 
   isUserEntered() {
     const event = this.getDetails();
-    const { tty, group_leader: groupLeader, parent } = event.process;
+    const { tty } = event.process;
 
-    return !!tty && groupLeader && groupLeader.pid !== parent.group_leader.pid;
+    return !!tty && process.pid !== event.process.group_leader.pid;
   }
 
   getMaxAlertLevel() {

--- a/x-pack/plugins/session_view/public/components/ProcessTreeNode/index.tsx
+++ b/x-pack/plugins/session_view/public/components/ProcessTreeNode/index.tsx
@@ -83,7 +83,7 @@ export function ProcessTreeNode({
     return null;
   }
 
-  const { interactive } = processDetails.process;
+  const { tty } = processDetails.process;
 
   const renderChildren = () => {
     const children = process.getChildren(showGroupLeadersOnly);
@@ -194,7 +194,7 @@ export function ProcessTreeNode({
 
   const renderSessionLeader = () => {
     const { name, args, user } = process.getDetails().process;
-    const sessionIcon = interactive ? 'consoleApp' : 'compute';
+    const sessionIcon = !!tty ? 'consoleApp' : 'compute';
 
     return (
       <>

--- a/x-pack/plugins/session_view/public/components/SessionLeaderTable/index.tsx
+++ b/x-pack/plugins/session_view/public/components/SessionLeaderTable/index.tsx
@@ -68,7 +68,7 @@ const DEFAULT_COLUMNS: ColumnHeaderOptions[] = [
   },
   {
     columnHeaderType: 'not-filtered',
-    id: 'process.session_leader.pid',
+    id: 'process.entry_leader.pid',
     initialWidth: 180,
     isSortable: true,
   },

--- a/x-pack/plugins/session_view/public/components/SessionLeaderTable/index.tsx
+++ b/x-pack/plugins/session_view/public/components/SessionLeaderTable/index.tsx
@@ -68,7 +68,7 @@ const DEFAULT_COLUMNS: ColumnHeaderOptions[] = [
   },
   {
     columnHeaderType: 'not-filtered',
-    id: 'process.session.pid',
+    id: 'process.session_leader.pid',
     initialWidth: 180,
     isSortable: true,
   },

--- a/x-pack/plugins/session_view/public/components/SessionView/index.tsx
+++ b/x-pack/plugins/session_view/public/components/SessionView/index.tsx
@@ -5,13 +5,7 @@
  * 2.0.
  */
 import React, { useState } from 'react';
-import {
-  EuiEmptyPrompt,
-  EuiButton,
-  EuiSplitPanel,
-  EuiFlexGroup,
-  EuiFlexItem,
-} from '@elastic/eui';
+import { EuiEmptyPrompt, EuiButton, EuiSplitPanel, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { SectionLoading } from '../../shared_imports';
 import { ProcessTree } from '../ProcessTree';
@@ -22,7 +16,7 @@ import { useStyles } from './styles';
 import { useFetchSessionViewProcessEvents } from './hooks';
 
 interface SessionViewDeps {
-  // the root node of the process tree to render. e.g process.entry.entity_id or process.session.entity_id
+  // the root node of the process tree to render. e.g process.entry.entity_id or process.session_leader.entity_id
   sessionEntityId: string;
   height?: number;
   jumpToEvent?: ProcessEvent;
@@ -45,7 +39,7 @@ export const SessionView = ({ sessionEntityId, height, jumpToEvent }: SessionVie
   };
 
   const [searchQuery, setSearchQuery] = useState('');
-  const [searchResults, setSearchResults ] = useState<Process[] | null>(null);
+  const [searchResults, setSearchResults] = useState<Process[] | null>(null);
 
   const {
     data,
@@ -142,12 +136,12 @@ export const SessionView = ({ sessionEntityId, height, jumpToEvent }: SessionVie
     <>
       <EuiFlexGroup>
         <EuiFlexItem data-test-subj="sessionViewProcessEventsSearch" css={{ position: 'relative' }}>
-          <SessionViewSearchBar 
+          <SessionViewSearchBar
             searchQuery={searchQuery}
             setSearchQuery={setSearchQuery}
-            setSelectedProcess={setSelectedProcess} 
-            searchResults={searchResults} 
-          />          
+            setSelectedProcess={setSelectedProcess}
+            searchResults={searchResults}
+          />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiButton

--- a/x-pack/plugins/session_view/public/components/SessionViewPage/index.tsx
+++ b/x-pack/plugins/session_view/public/components/SessionViewPage/index.tsx
@@ -56,7 +56,7 @@ export const SessionViewPage = (props: RouteComponentProps) => {
 
     if (data.hits.length) {
       const event = data.hits[0]._source as ProcessEvent;
-      setSessionEntityId(event.process.entry.entity_id);
+      setSessionEntityId(event.process.entry_leader.entity_id);
     }
   }, [data]);
 

--- a/x-pack/plugins/session_view/server/routes/process_events_route.ts
+++ b/x-pack/plugins/session_view/server/routes/process_events_route.ts
@@ -38,7 +38,7 @@ export const doSearch = async (
   cursor: string | undefined,
   forward = true
 ) => {
-  // Temporary hack. Updates .siem-signals-default index to include a mapping for process.entry.entity_id
+  // Temporary hack. Updates .siem-signals-default index to include a mapping for process.entry_leader.entity_id
   // TODO: find out how to do proper index mapping migrations...
   let siemSignalsExists = true;
 
@@ -47,7 +47,7 @@ export const doSearch = async (
       index: '.siem-signals-default',
       body: {
         properties: {
-          'process.entry.entity_id': {
+          'process.entry_leader.entity_id': {
             type: 'keyword',
           },
         },
@@ -68,7 +68,7 @@ export const doSearch = async (
     body: {
       query: {
         match: {
-          'process.entry.entity_id': sessionEntityId,
+          'process.entry_leader.entity_id': sessionEntityId,
         },
       },
       size: PROCESS_EVENTS_PER_PAGE,

--- a/x-pack/plugins/session_view/server/routes/recent_session_route.ts
+++ b/x-pack/plugins/session_view/server/routes/recent_session_route.ts
@@ -28,7 +28,7 @@ export const registerRecentSessionRoute = (router: IRouter) => {
         body: {
           query: {
             match: {
-              'process.entry.interactive': true,
+              'process.entry_leader.interactive': true,
             },
           },
           size: 1,


### PR DESCRIPTION
Not compatible with current EventConverter schema, will push a PR on that repo to match ECS schema

TODO:
- update mock data
- update es archives
- update tests