### PR TITLE
tiny fix for spacing issue between searchbar and session view

### DIFF
--- a/x-pack/plugins/session_view/public/components/SessionView/styles.ts
+++ b/x-pack/plugins/session_view/public/components/SessionView/styles.ts
@@ -6,18 +6,26 @@
  */
 
 import { useMemo } from 'react';
+import { useEuiTheme } from '@elastic/eui';
 import { CSSObject } from '@emotion/react';
+
 
 interface StylesDeps {
   height: number | undefined;
 }
 
 export const useStyles = ({ height = 500 }: StylesDeps) => {
+
+  const { euiTheme } = useEuiTheme();
+
   const cached = useMemo(() => {
     // const { colors, border, font, size } = euiTheme;
 
+    const padding = euiTheme.size.s;
+  
     const processTree: CSSObject = {
       height: `${height}px`,
+      paddingTop: padding,
     };
 
     const detailPanel: CSSObject = {

--- a/x-pack/plugins/session_view/public/components/SessionView/styles.ts
+++ b/x-pack/plugins/session_view/public/components/SessionView/styles.ts
@@ -20,12 +20,10 @@ export const useStyles = ({ height = 500 }: StylesDeps) => {
 
   const cached = useMemo(() => {
     // const { colors, border, font, size } = euiTheme;
-
-    const padding = euiTheme.size.s;
   
     const processTree: CSSObject = {
       height: `${height}px`,
-      paddingTop: padding,
+      paddingTop: euiTheme.size.s,
     };
 
     const detailPanel: CSSObject = {


### PR DESCRIPTION
## Summary
Tiny fix for issue Jack told me yesterday about no space between search bar and session view
<img width="1603" alt="Screen Shot 2022-02-07 at 4 20 34 PM" src="https://user-images.githubusercontent.com/8703149/153064825-bb4164cf-8a85-4a5f-b6bb-8ec557bf6f98.png">
**Before**

![Uploading Screen Shot 2022-02-08 at 11.51.30 AM.png…]()
**After**



