### PR TITLE
Updating Session View index to work with endpoint integration

### DIFF
--- a/x-pack/plugins/session_view/common/types/process_tree/index.ts
+++ b/x-pack/plugins/session_view/common/types/process_tree/index.ts
@@ -68,8 +68,8 @@ export interface ProcessFields {
   interactive: boolean;
   working_directory: string;
   pid: number;
-  start: Date;
-  end?: Date;
+  start: string;
+  end?: string;
   user: User;
   exit_code?: number;
   entry_meta?: EntryMeta;
@@ -79,6 +79,7 @@ export interface ProcessFields {
 export interface ProcessSelf extends Omit<ProcessFields, 'user'> {
   parent: ProcessFields;
   session_leader: ProcessFields;
+  session: ProcessFields;
   entry_leader: ProcessFields;
   group_leader: ProcessFields;
 }
@@ -125,7 +126,7 @@ export interface ProcessEventAlert {
 }
 
 export interface ProcessEvent {
-  '@timestamp': Date;
+  '@timestamp': string;
   event: {
     kind: EventKind;
     category: string;

--- a/x-pack/plugins/session_view/common/types/process_tree/index.ts
+++ b/x-pack/plugins/session_view/common/types/process_tree/index.ts
@@ -79,6 +79,8 @@ export interface ProcessFields {
 export interface ProcessSelf extends Omit<ProcessFields, 'user'> {
   parent: ProcessFields;
   session_leader: ProcessFields;
+  // replacing session_leader with session as a Temporary implementation for the endpoint integration
+  // TODO: revert to session_leader once it's ready
   session: ProcessFields;
   entry_leader: ProcessFields;
   group_leader: ProcessFields;

--- a/x-pack/plugins/session_view/public/components/DetailPanelProcessTab/index.tsx
+++ b/x-pack/plugins/session_view/public/components/DetailPanelProcessTab/index.tsx
@@ -71,8 +71,8 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
       {
         title: <DetailPanelListItem>start</DetailPanelListItem>,
         description: (
-          <DetailPanelCopy textToCopy={leader.start.toISOString()}>
-            <span css={styles.description}>{leader.start.toISOString()}</span>
+          <DetailPanelCopy textToCopy={leader.start}>
+            <span css={styles.description}>{leader.start}</span>
           </DetailPanelCopy>
         ),
       },
@@ -157,16 +157,16 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
           {
             title: <DetailPanelListItem>start</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={processDetail.start.toISOString()}>
-                <span css={styles.description}>{processDetail.start.toISOString()}</span>
+              <DetailPanelCopy textToCopy={processDetail.start}>
+                <span css={styles.description}>{processDetail.start}</span>
               </DetailPanelCopy>
             ),
           },
           {
             title: <DetailPanelListItem>end</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={processDetail.end.toISOString()}>
-                <span css={styles.description}>{processDetail.end.toISOString()}</span>
+              <DetailPanelCopy textToCopy={processDetail.end}>
+                <span css={styles.description}>{processDetail.end}</span>
               </DetailPanelCopy>
             ),
           },

--- a/x-pack/plugins/session_view/public/components/SessionLeaderTable/index.tsx
+++ b/x-pack/plugins/session_view/public/components/SessionLeaderTable/index.tsx
@@ -86,7 +86,7 @@ startDate.setDate(new Date().getDate() - 7);
 const DEFAULT_END_DATE = new Date().toISOString();
 const DEFAULT_START_DATE = startDate.toISOString();
 
-const DEFAULT_INDEX_NAMES = ['cmd_entry_leader*'];
+const DEFAULT_INDEX_NAMES = ['logs-endpoint.events.process-default*'];
 
 const DEFAULT_ITEMS_PER_PAGE = [10, 25, 50];
 

--- a/x-pack/plugins/session_view/public/components/SessionViewDetailPanel/helpers.ts
+++ b/x-pack/plugins/session_view/public/components/SessionViewDetailPanel/helpers.ts
@@ -48,7 +48,7 @@ export const getDetailPanelProcess = (process: Process | null) => {
 
   processData.args = [...args];
   processData.entryLeader = getDetailPanelProcessLeader(process.events[0].process.entry_leader);
-  processData.sessionLeader = getDetailPanelProcessLeader(process.events[0].process.session_leader);
+  processData.sessionLeader = getDetailPanelProcessLeader(process.events[0].process.session);
   processData.groupLeader = getDetailPanelProcessLeader(process.events[0].process.group_leader);
   processData.parent = getDetailPanelProcessLeader(process.events[0].process.parent);
 

--- a/x-pack/plugins/session_view/public/components/SessionViewPage/index.tsx
+++ b/x-pack/plugins/session_view/public/components/SessionViewPage/index.tsx
@@ -36,7 +36,7 @@ export const SessionViewPage = (props: RouteComponentProps) => {
     () => {
       return http.get<RecentSessionResults>(RECENT_SESSION_ROUTE, {
         query: {
-          indexes: ['cmd*', '.siem-signals*'],
+          indexes: ['logs-endpoint.events.process-default*', '.siem-signals*'],
         },
       });
     },

--- a/x-pack/plugins/session_view/public/types.ts
+++ b/x-pack/plugins/session_view/public/types.ts
@@ -17,8 +17,8 @@ export type SessionViewServices = CoreStart & {
 
 export interface DetailPanelProcess {
   id: string;
-  start: Date;
-  end: Date;
+  start: string;
+  end: string;
   exit_code: number;
   user: string;
   args: string[];
@@ -33,7 +33,7 @@ export interface DetailPanelProcess {
 export interface DetailPanelProcessLeader {
   id: string;
   name: string;
-  start: Date;
+  start: string;
   entryMetaType: string;
   userName: string;
   interactive: boolean;

--- a/x-pack/plugins/session_view/server/routes/process_events_route.ts
+++ b/x-pack/plugins/session_view/server/routes/process_events_route.ts
@@ -57,7 +57,7 @@ export const doSearch = async (
     siemSignalsExists = false;
   }
 
-  const indices = ['cmd'];
+  const indices = ['logs-endpoint.events.process-default'];
 
   if (siemSignalsExists) {
     indices.push('.siem-signals-default');

--- a/x-pack/plugins/session_view/server/routes/session_entry_leaders_route.ts
+++ b/x-pack/plugins/session_view/server/routes/session_entry_leaders_route.ts
@@ -23,7 +23,7 @@ export const sessionEntryLeadersRoute = (router: IRouter) => {
       const { id } = request.query;
 
       const result = await client.get({
-        index: 'cmd_entry_leader',
+        index: 'logs-endpoint.events.process-default',
         id,
       });
 


### PR DESCRIPTION
### Overview

This PR addresses the changes needed to see a working demo of the Session View with endpoint integrated data.

- Loads data from `logs-endpoint.events.process-default*` index

Only working for the most recent session, not updating the Session Leader Table by now.


### Screenshot

![image](https://user-images.githubusercontent.com/19270322/154090975-2f96fd1f-ee04-4197-afcf-dc90977240fe.png)
