### PR TITLE
Wrap renderChildren in a div

### DIFF
--- a/x-pack/plugins/session_view/public/components/ProcessTreeNode/index.tsx
+++ b/x-pack/plugins/session_view/public/components/ProcessTreeNode/index.tsx
@@ -89,7 +89,7 @@ export function ProcessTreeNode({
     const children = process.getChildren(showGroupLeadersOnly);
 
     if (!childrenExpanded || !children || children.length === 0) {
-      return;
+      return null;
     }
 
     const newDepth = depth + 1;
@@ -307,7 +307,7 @@ export function ProcessTreeNode({
         </div>
       </div>
       {alertsExpanded && <ProcessTreeAlerts alerts={alerts} />}
-      {renderChildren()}
+      <div>{renderChildren()}</div>
     </>
   );
 }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/16872649/154366543-da1c9719-2681-4bd1-b3c1-7eb4a6f8fa28.png)


Seems like `<></>` is unhappy when there are conditional rendering with `.map` outside of the return method and there is only 1 line in the process tree.

Looks like a react bug, work around is just to wrap the rendering method with a wrapper