### PR TITLE
Pr feedback

### DIFF
--- a/x-pack/plugins/session_view/common/utils/sort_processes.test.ts
+++ b/x-pack/plugins/session_view/common/utils/sort_processes.test.ts
@@ -6,11 +6,10 @@
  */
 
 import { sortProcesses } from './sort_processes';
-import { Process } from '../types/process_tree';
 import { mockProcessMap } from '../mocks/constants/session_view_process.mock';
 
 describe('sortProcesses(a, b)', () => {
-  it('works', () => {
+  it('sorts processes in ascending order by start time', () => {
     const processes = Object.values(mockProcessMap);
 
     // shuffle some things to ensure all sort lines are hit
@@ -18,17 +17,12 @@ describe('sortProcesses(a, b)', () => {
     processes[0] = processes[processes.length - 1];
     processes[processes.length - 1] = c;
 
-    const sorted = processes.sort(sortProcesses);
+    processes.sort(sortProcesses);
 
-    let lastProcess: Process;
-
-    sorted.forEach((process) => {
-      if (
-        lastProcess &&
-        lastProcess.getDetails().process.start > process.getDetails().process.start
-      ) {
-        throw new Error('processes not sorted by process.start');
-      }
-    });
+    for (let i = 0; i < processes.length - 1; i++) {
+      const current = processes[i];
+      const next = processes[i+1];
+      expect(new Date(next.getDetails().process.start) >= new Date(current.getDetails().process.start)).toBeTruthy();
+    }
   });
 });

--- a/x-pack/plugins/session_view/common/utils/sort_processes.ts
+++ b/x-pack/plugins/session_view/common/utils/sort_processes.ts
@@ -8,14 +8,14 @@
 import { Process } from '../types/process_tree';
 
 export const sortProcesses = (a: Process, b: Process) => {
-  const eventA = a.getDetails();
-  const eventB = b.getDetails();
+  const eventAStartTime = new Date(a.getDetails().process.start);
+  const eventBStartTime = new Date(b.getDetails().process.start);
 
-  if (eventA.process.start < eventB.process.start) {
+  if (eventAStartTime < eventBStartTime) {
     return -1;
   }
 
-  if (eventA.process.start > eventB.process.start) {
+  if (eventAStartTime > eventBStartTime) {
     return 1;
   }
 


### PR DESCRIPTION
## Summary

process.start is a string timestamp, it was being compared with `>`, `<`. Additionally, the test for sort_process was a no-op as it never assigned anything to the value that was checked in the condition