### PR TITLE
Session view kg addressed comments

### DIFF
--- a/x-pack/plugins/session_view/common/constants.ts
+++ b/x-pack/plugins/session_view/common/constants.ts
@@ -9,4 +9,17 @@ export const PROCESS_EVENTS_ROUTE = '/internal/session_view/process_events_route
 export const RECENT_SESSION_ROUTE = '/internal/session_view/recent_session_route';
 export const SESSION_ENTRY_LEADERS_ROUTE = '/internal/session_view/session_entry_leaders_route';
 
+// We fetch a large number of events per page to mitigate a few design caveats in session viewer
+// 1. Due to the hierarchical nature of the data (e.g we are rendering a time ordered pid tree) there are common scenarios where there
+//    are few top level processes, but many nested children. For example, a build script is run on a remote host via ssh. If for example our page
+//    size is 10 and the build script has 500 nested children, the user would see a load more button that they could continously click without seeing
+//    anychange since the next 10 events would be for processes nested under a top level process that might not be expanded. That being said, it's quite
+//    possible there are build scripts with many thousands of events, in which case this initial large page will have the same issue. A technique used
+//    in previous incarnations of session view included auto expanding the node which is receiving the new page of events so as to not confuse the user.
+//    We may need to include this trick as part of this implementation as well.
+// 2. The plain text search that comes with Session view is currently limited in that it only searches through data that has been loaded into the browser.
+//    The large page size allows the user to get a broader set of results per page. That being said, this feature is kind of flawed since sessions could be many thousands
+//    if not 100s of thousands of events, and to be required to page through these sessions to find more search matches is not a great experience. Future iterations of the
+//    search functionality will instead use a separate ES backend search to avoid this.
+// 3. Fewer round trips to the backend!
 export const PROCESS_EVENTS_PER_PAGE = 1000;

--- a/x-pack/plugins/session_view/common/constants.ts
+++ b/x-pack/plugins/session_view/common/constants.ts
@@ -8,6 +8,9 @@
 export const PROCESS_EVENTS_ROUTE = '/internal/session_view/process_events_route';
 export const RECENT_SESSION_ROUTE = '/internal/session_view/recent_session_route';
 export const SESSION_ENTRY_LEADERS_ROUTE = '/internal/session_view/session_entry_leaders_route';
+export const PROCESS_EVENTS_INDEX = 'logs-endpoint.events.process-default';
+export const ALERTS_INDEX = '.siem-signals-default';
+export const ENTRY_SESSION_ENTITY_ID_PROPERTY = 'process.entry_leader.entity_id';
 
 // We fetch a large number of events per page to mitigate a few design caveats in session viewer
 // 1. Due to the hierarchical nature of the data (e.g we are rendering a time ordered pid tree) there are common scenarios where there

--- a/x-pack/plugins/session_view/public/components/process_tree_node/index.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree_node/index.tsx
@@ -114,6 +114,8 @@ export function ProcessTreeNode({
     return expanded ? 'arrowUp' : 'arrowDown';
   };
 
+  const onShowGroupLeaderOnlyClick = () => setShowGroupLeadersOnly(!showGroupLeadersOnly);
+
   const renderButtons = () => {
     const buttons = [];
     const childCount = process.getChildren().length;
@@ -137,9 +139,9 @@ export function ProcessTreeNode({
             }
           >
             <EuiButton
-              key="child-processes-button"
+              key="group-leaders-only-button"
               css={styles.getButtonStyle(ButtonType.children)}
-              onClick={() => setShowGroupLeadersOnly(!showGroupLeadersOnly)}
+              onClick={onShowGroupLeaderOnlyClick}
               data-test-subj="processTreeNodeChildProcessesButton"
             >
               <FormattedMessage

--- a/x-pack/plugins/session_view/public/components/process_tree_node/index.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree_node/index.tsx
@@ -11,7 +11,7 @@
  *2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useMemo, useRef, useLayoutEffect, useState, useEffect, MouseEvent } from 'react';
+import React, { useRef, useLayoutEffect, useState, useEffect, MouseEvent } from 'react';
 import { EuiButton, EuiIcon, EuiToolTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { Process } from '../../../common/types/process_tree';
@@ -46,20 +46,9 @@ export function ProcessTreeNode({
     setChildrenExpanded(isSessionLeader || process.autoExpand);
   }, [isSessionLeader, process.autoExpand]);
 
-  const processDetails = useMemo(() => {
-    return process.getDetails();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [process.events.length]);
-
-  const hasExec = useMemo(() => {
-    return process.hasExec();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [process.events.length]);
-
-  const alerts = useMemo(() => {
-    return process.getAlerts();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [process.events.length]);
+  const processDetails = process.getDetails();
+  const hasExec = process.hasExec();
+  const alerts = process.getAlerts();
 
   const styles = useStyles({ depth, hasAlerts: !!alerts.length });
 

--- a/x-pack/plugins/session_view/public/components/session_leader_table/index.tsx
+++ b/x-pack/plugins/session_view/public/components/session_leader_table/index.tsx
@@ -16,6 +16,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { useStyles } from './styles';
 import { SessionViewServices } from '../../types';
+import { PROCESS_EVENTS_INDEX } from '../../../common/constants';
 import { useKibana } from '../../../../../../src/plugins/kibana_react/public';
 import {
   ColumnHeaderOptions,
@@ -87,7 +88,7 @@ startDate.setDate(new Date().getDate() - 7);
 const DEFAULT_END_DATE = new Date().toISOString();
 const DEFAULT_START_DATE = startDate.toISOString();
 
-const DEFAULT_INDEX_NAMES = ['logs-endpoint.events.process-default*'];
+const DEFAULT_INDEX_NAMES = [PROCESS_EVENTS_INDEX];
 
 const DEFAULT_ITEMS_PER_PAGE = [10, 25, 50];
 

--- a/x-pack/plugins/session_view/server/plugin.ts
+++ b/x-pack/plugins/session_view/server/plugin.ts
@@ -31,7 +31,7 @@ export class SessionViewPlugin implements Plugin {
     const router = core.http.createRouter();
 
     // Register server routes
-    registerRoutes(router, this.logger);
+    registerRoutes(router);
   }
 
   public start(core: CoreStart, plugins: SessionViewStartPlugins) {

--- a/x-pack/plugins/session_view/server/routes/index.ts
+++ b/x-pack/plugins/session_view/server/routes/index.ts
@@ -4,14 +4,13 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type { Logger } from 'kibana/server';
 import { IRouter } from '../../../../../src/core/server';
 import { registerProcessEventsRoute } from './process_events_route';
 import { registerRecentSessionRoute } from './recent_session_route';
 import { sessionEntryLeadersRoute } from './session_entry_leaders_route';
 
-export const registerRoutes = (router: IRouter, logger: Logger) => {
-  registerProcessEventsRoute(router, logger);
+export const registerRoutes = (router: IRouter) => {
+  registerProcessEventsRoute(router);
   registerRecentSessionRoute(router);
   sessionEntryLeadersRoute(router);
 };

--- a/x-pack/plugins/session_view/server/routes/process_events_route.test.ts
+++ b/x-pack/plugins/session_view/server/routes/process_events_route.test.ts
@@ -10,24 +10,20 @@ import { mockEvents } from '../../common/mocks/constants/session_view_process.mo
 
 const getEmptyResponse = async () => {
   return {
-    body: {
-      hits: {
-        total: { value: 0, relation: 'eq' },
-        hits: [],
-      },
+    hits: {
+      total: { value: 0, relation: 'eq' },
+      hits: [],
     },
   };
 };
 
 const getResponse = async () => {
   return {
-    body: {
-      hits: {
-        total: { value: mockEvents.length, relation: 'eq' },
-        hits: mockEvents.map((event) => {
-          return { _source: event };
-        }),
-      },
+    hits: {
+      total: { value: mockEvents.length, relation: 'eq' },
+      hits: mockEvents.map((event) => {
+        return { _source: event };
+      }),
     },
   };
 };

--- a/x-pack/plugins/session_view/server/routes/session_entry_leaders_route.ts
+++ b/x-pack/plugins/session_view/server/routes/session_entry_leaders_route.ts
@@ -6,7 +6,7 @@
  */
 import { schema } from '@kbn/config-schema';
 import { IRouter } from '../../../../../src/core/server';
-import { SESSION_ENTRY_LEADERS_ROUTE } from '../../common/constants';
+import { SESSION_ENTRY_LEADERS_ROUTE, PROCESS_EVENTS_INDEX } from '../../common/constants';
 
 export const sessionEntryLeadersRoute = (router: IRouter) => {
   router.get(
@@ -23,7 +23,7 @@ export const sessionEntryLeadersRoute = (router: IRouter) => {
       const { id } = request.query;
 
       const result = await client.get({
-        index: 'logs-endpoint.events.process-default',
+        index: PROCESS_EVENTS_INDEX,
         id,
       });
 


### PR DESCRIPTION
- adds explaination for large process event page size
- made constants out of the indexes and entity_id prop paths in process_events_route
- fixed process_events_route tests. (there was a change to the elastic mock code which caused them to break)
- useMemo in ProcessTreeNode removed in favor of memoizeOne of the functions in ProcessImpl