### PR TITLE
fix to cache bust issue on memoize functions. we were mutating the ar…

### DIFF
--- a/x-pack/plugins/session_view/common/types/process_tree/index.ts
+++ b/x-pack/plugins/session_view/common/types/process_tree/index.ts
@@ -152,6 +152,7 @@ export interface Process {
   parent: Process | undefined;
   autoExpand: boolean;
   searchMatched: string | null; // either false, or set to searchQuery
+  addEvent(event: ProcessEvent): void;
   hasOutput(): boolean;
   hasAlerts(): boolean;
   getAlerts(): ProcessEvent[];

--- a/x-pack/plugins/session_view/public/components/process_tree/helpers.ts
+++ b/x-pack/plugins/session_view/public/components/process_tree/helpers.ts
@@ -17,7 +17,7 @@ export const updateProcessMap = (processMap: ProcessMap, events: ProcessEvent[])
       processMap[id] = process;
     }
 
-    process.events.push(event);
+    process.addEvent(event);
   });
 
   return processMap;

--- a/x-pack/plugins/session_view/public/components/process_tree/hooks.test.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree/hooks.test.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EventAction } from '../../../common/types/process_tree';
+import { mockEvents } from '../../../common/mocks/constants/session_view_process.mock';
+import { ProcessImpl } from './hooks';
+
+describe('ProcessTree hooks', () => {
+  describe('ProcessImpl.getDetails memoize will cache bust on new events', () => {
+    it('should return the exec event details when this.events changes', () => {
+      const process = new ProcessImpl(mockEvents[0].process.entity_id);
+
+      process.addEvent(mockEvents[0]);
+
+      let result = process.getDetails();
+
+      // push exec event
+      process.addEvent(mockEvents[1]);
+
+      result = process.getDetails();
+
+      expect(result.event.action).toEqual(EventAction.exec);
+    });
+  });
+});

--- a/x-pack/plugins/session_view/public/components/process_tree/index.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree/index.tsx
@@ -148,7 +148,7 @@ export const ProcessTree = ({
 
   function renderLoadMoreButton(text: JSX.Element, func: FetchFunction) {
     return (
-      <EuiButton fullWidth onClick={() => func()} isLoading={isFetching}>
+      <EuiButton fullWidth onClick={func} isLoading={isFetching}>
         {text}
       </EuiButton>
     );


### PR DESCRIPTION
-memoizeOne functions will now work correctly as i've added a addEvent function which will create a new array ref on each added event, thus helping cache bust the memoized functions.
-isUserEntered calculation was backwards
-removed unneeded intermediate inline function.