### PR TITLE
Revert timestamp and related fields to string type and fixes

### DIFF
--- a/x-pack/plugins/session_view/common/mocks/responses/session_view_process_events.mock.ts
+++ b/x-pack/plugins/session_view/common/mocks/responses/session_view_process_events.mock.ts
@@ -14,7 +14,7 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
       _id: 'FMUGTX0BGGlsPv9flMF7',
       _score: null,
       _source: {
-        '@timestamp': new Date('2021-11-23T13:40:16.528Z'),
+        '@timestamp': '2021-11-23T13:40:16.528Z',
         event: {
           kind: 'event',
           category: 'process',
@@ -78,7 +78,7 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
           interactive: false,
           working_directory: '/',
           pid: 3,
-          start: new Date('2021-10-14T08:05:34.853Z'),
+          start: '2021-10-14T08:05:34.853Z',
           parent: {
             entity_id: '4322',
             args: ['/bin/sshd'],
@@ -89,7 +89,7 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             interactive: true,
             working_directory: '/',
             pid: 2,
-            start: new Date('2021-10-14T08:05:34.853Z'),
+            start: '2021-10-14T08:05:34.853Z',
             user: {
               id: '2',
               name: 'kg',
@@ -127,7 +127,7 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             group_leader: {
               entity_id: '0fe5f6a0-6f04-49a5-8faf-768445b38d16',
               pid: 1234, // this directly replaces parent.pgid
-              start: new Date('2021-10-14T08:05:34.853Z'),
+              start: '2021-10-14T08:05:34.853Z',
             },
             file_descriptions: [
               {
@@ -158,7 +158,7 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             interactive: true,
             working_directory: '/home/kg',
             pid: 3,
-            start: new Date('2021-10-14T08:05:34.853Z'),
+            start: '2021-10-14T08:05:34.853Z',
             user: {
               id: '0',
               name: 'root',
@@ -222,7 +222,7 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             interactive: true,
             working_directory: '/home/kg',
             pid: 3,
-            start: new Date('2021-10-14T08:05:34.853Z'),
+            start: '2021-10-14T08:05:34.853Z',
             user: {
               id: '0',
               name: 'root',
@@ -260,12 +260,12 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             // parent: {
             //   entity_id: '0fe5f6a0-6f04-49a5-8faf-768445b38d16',
             //   pid: 2,
-            //   start: new Date('2021-10-14T08:05:34.853Z'),
+            //   start: '2021-10-14T08:05:34.853Z',
             //   session_leader: {
             //     // used as a foreign key to the parent session of the session_leader
             //     entity_id: '0fe5f6a0-6f04-49a5-8faf-768445b38d16',
             //     pid: 4321,
-            //     start: new Date('2021-10-14T08:05:34.853Z'),
+            //     start: '2021-10-14T08:05:34.853Z',
             //   },
             // },
             file_descriptions: [
@@ -297,7 +297,7 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             interactive: true,
             working_directory: '/home/kg',
             pid: 3,
-            start: new Date('2021-10-14T08:05:34.853Z'),
+            start: '2021-10-14T08:05:34.853Z',
             user: {
               id: '0',
               name: 'root',
@@ -335,12 +335,12 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             // parent: {
             //   entity_id: '0fe5f6a0-6f04-49a5-8faf-768445b38d16',
             //   pid: 2,
-            //   start: new Date('2021-10-14T08:05:34.853Z'),
+            //   start: '2021-10-14T08:05:34.853Z',
             //   session_leader: {
             //     // used as a foreign key to the parent session of the entry_leader
             //     entity_id: '0fe5f6a0-6f04-49a5-8faf-768445b38d16',
             //     pid: 4321,
-            //     start: new Date('2021-10-14T08:05:34.853Z'),
+            //     start: '2021-10-14T08:05:34.853Z',
             //   },
             // },
             entry_meta: {
@@ -417,7 +417,7 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
       _id: 'FsUGTX0BGGlsPv9flMGF',
       _score: null,
       _source: {
-        '@timestamp': new Date('2021-11-23T13:40:16.541Z'),
+        '@timestamp': '2021-11-23T13:40:16.541Z',
         event: {
           kind: 'event',
           category: 'process',
@@ -486,7 +486,7 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
           interactive: true,
           working_directory: '/home/kg',
           pid: 3,
-          start: new Date('2021-10-14T08:05:34.853Z'),
+          start: '2021-10-14T08:05:34.853Z',
           previous: [{ args: ['/bin/sshd'], args_count: 1, executable: '/bin/sshd' }],
           parent: {
             entity_id: '4322',
@@ -498,7 +498,7 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             interactive: true,
             working_directory: '/',
             pid: 2,
-            start: new Date('2021-10-14T08:05:34.853Z'),
+            start: '2021-10-14T08:05:34.853Z',
             user: {
               id: '0',
               name: 'root',
@@ -536,7 +536,7 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             group_leader: {
               entity_id: '0fe5f6a0-6f04-49a5-8faf-768445b38d16',
               pid: 1234, // this directly replaces parent.pgid
-              start: new Date('2021-10-14T08:05:34.853Z'),
+              start: '2021-10-14T08:05:34.853Z',
             },
             file_descriptions: [
               {
@@ -567,7 +567,7 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             interactive: true,
             working_directory: '/home/kg',
             pid: 3,
-            start: new Date('2021-10-14T08:05:34.853Z'),
+            start: '2021-10-14T08:05:34.853Z',
             user: {
               id: '0',
               name: 'root',
@@ -631,7 +631,7 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             interactive: true,
             working_directory: '/home/kg',
             pid: 3,
-            start: new Date('2021-10-14T08:05:34.853Z'),
+            start: '2021-10-14T08:05:34.853Z',
             user: {
               id: '0',
               name: 'root',
@@ -669,12 +669,12 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             // parent: {
             //   entity_id: '0fe5f6a0-6f04-49a5-8faf-768445b38d16',
             //   pid: 2,
-            //   start: new Date('2021-10-14T08:05:34.853Z'),
+            //   start: '2021-10-14T08:05:34.853Z',
             //   session_leader: {
             //     // used as a foreign key to the parent session of the session_leader
             //     entity_id: '0fe5f6a0-6f04-49a5-8faf-768445b38d16',
             //     pid: 4321,
-            //     start: new Date('2021-10-14T08:05:34.853Z'),
+            //     start: '2021-10-14T08:05:34.853Z',
             //   },
             // },
             file_descriptions: [
@@ -706,7 +706,7 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             interactive: true,
             working_directory: '/home/kg',
             pid: 3,
-            start: new Date('2021-10-14T08:05:34.853Z'),
+            start: '2021-10-14T08:05:34.853Z',
             user: {
               id: '0',
               name: 'root',
@@ -744,12 +744,12 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             // parent: {
             //   entity_id: '0fe5f6a0-6f04-49a5-8faf-768445b38d16',
             //   pid: 2,
-            //   start: new Date('2021-10-14T08:05:34.853Z'),
+            //   start: '2021-10-14T08:05:34.853Z',
             //   session_leader: {
             //     // used as a foreign key to the parent session of the entry_leader
             //     entity_id: '0fe5f6a0-6f04-49a5-8faf-768445b38d16',
             //     pid: 4321,
-            //     start: new Date('2021-10-14T08:05:34.853Z'),
+            //     start: '2021-10-14T08:05:34.853Z',
             //   },
             // },
             entry_meta: {
@@ -826,7 +826,7 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
       _id: 'H8UGTX0BGGlsPv9fp8F_',
       _score: null,
       _source: {
-        '@timestamp': new Date('2021-11-23T13:40:21.392Z'),
+        '@timestamp': '2021-11-23T13:40:21.392Z',
         event: {
           kind: 'event',
           category: 'process',
@@ -895,8 +895,8 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
           interactive: true,
           working_directory: '/home/kg',
           pid: 3,
-          start: new Date('2021-10-14T08:05:34.853Z'),
-          end: new Date('2021-10-14T10:05:34.853Z'),
+          start: '2021-10-14T08:05:34.853Z',
+          end: '2021-10-14T10:05:34.853Z',
           exit_code: 137,
           previous: [{ args: ['/bin/sshd'], args_count: 1, executable: '/bin/sshd' }],
           parent: {
@@ -909,7 +909,7 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             interactive: true,
             working_directory: '/',
             pid: 2,
-            start: new Date('2021-10-14T08:05:34.853Z'),
+            start: '2021-10-14T08:05:34.853Z',
             user: {
               id: '0',
               name: 'root',
@@ -947,7 +947,7 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             group_leader: {
               entity_id: '0fe5f6a0-6f04-49a5-8faf-768445b38d16',
               pid: 1234, // this directly replaces parent.pgid
-              start: new Date('2021-10-14T08:05:34.853Z'),
+              start: '2021-10-14T08:05:34.853Z',
             },
             file_descriptions: [
               {
@@ -978,7 +978,7 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             interactive: true,
             working_directory: '/home/kg',
             pid: 3,
-            start: new Date('2021-10-14T08:05:34.853Z'),
+            start: '2021-10-14T08:05:34.853Z',
             user: {
               id: '0',
               name: 'root',
@@ -1042,7 +1042,7 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             interactive: true,
             working_directory: '/home/kg',
             pid: 3,
-            start: new Date('2021-10-14T08:05:34.853Z'),
+            start: '2021-10-14T08:05:34.853Z',
             user: {
               id: '0',
               name: 'root',
@@ -1080,12 +1080,12 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             // parent: {
             //   entity_id: '0fe5f6a0-6f04-49a5-8faf-768445b38d16',
             //   pid: 2,
-            //   start: new Date('2021-10-14T08:05:34.853Z'),
+            //   start: '2021-10-14T08:05:34.853Z',
             //   session_leader: {
             //     // used as a foreign key to the parent session of the session_leader
             //     entity_id: '0fe5f6a0-6f04-49a5-8faf-768445b38d16',
             //     pid: 4321,
-            //     start: new Date('2021-10-14T08:05:34.853Z'),
+            //     start: '2021-10-14T08:05:34.853Z',
             //   },
             // },
             file_descriptions: [
@@ -1117,7 +1117,7 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             interactive: true,
             working_directory: '/home/kg',
             pid: 3,
-            start: new Date('2021-10-14T08:05:34.853Z'),
+            start: '2021-10-14T08:05:34.853Z',
             user: {
               id: '0',
               name: 'root',
@@ -1155,12 +1155,12 @@ export const sessionViewProcessEventsMock: ProcessEventResults = {
             // parent: {
             //   entity_id: '0fe5f6a0-6f04-49a5-8faf-768445b38d16',
             //   pid: 2,
-            //   start: new Date('2021-10-14T08:05:34.853Z'),
+            //   start: '2021-10-14T08:05:34.853Z',
             //   session_leader: {
             //     // used as a foreign key to the parent session of the entry_leader
             //     entity_id: '0fe5f6a0-6f04-49a5-8faf-768445b38d16',
             //     pid: 4321,
-            //     start: new Date('2021-10-14T08:05:34.853Z'),
+            //     start: '2021-10-14T08:05:34.853Z',
             //   },
             // },
             entry_meta: {

--- a/x-pack/plugins/session_view/common/types/process_tree/index.ts
+++ b/x-pack/plugins/session_view/common/types/process_tree/index.ts
@@ -125,7 +125,7 @@ export interface ProcessEventAlert {
 }
 
 export interface ProcessEvent {
-  '@timestamp': Date;
+  '@timestamp': string;
   event: {
     kind: EventKind;
     category: string;

--- a/x-pack/plugins/session_view/public/components/detail_panel_process_tab/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_process_tab/index.test.tsx
@@ -13,7 +13,7 @@ import { DetailPanelProcessTab } from './index';
 const getLeaderDetail = (leader: string): DetailPanelProcessLeader => ({
   id: `${leader}-id`,
   name: `${leader}-name`,
-  start: new Date('2022-02-24'),
+  start: new Date('2022-02-24').toISOString(),
   entryMetaType: 'sshd',
   userName: `${leader}-jack`,
   interactive: true,
@@ -24,8 +24,8 @@ const getLeaderDetail = (leader: string): DetailPanelProcessLeader => ({
 
 const TEST_PROCESS_DETAIL: DetailPanelProcess = {
   id: 'process-id',
-  start: new Date('2022-02-22'),
-  end: new Date('2022-02-23'),
+  start: new Date('2022-02-22').toISOString(),
+  end: new Date('2022-02-23').toISOString(),
   exit_code: 137,
   user: 'process-jack',
   args: ['vi', 'test.txt'],
@@ -58,8 +58,8 @@ describe('DetailPanelProcessTab component', () => {
 
       // Process detail rendered correctly
       expect(renderResult.queryByText(TEST_PROCESS_DETAIL.id)).toBeVisible();
-      expect(renderResult.queryByText(TEST_PROCESS_DETAIL.start.toISOString())).toBeVisible();
-      expect(renderResult.queryByText(TEST_PROCESS_DETAIL.end.toISOString())).toBeVisible();
+      expect(renderResult.queryByText(TEST_PROCESS_DETAIL.start)).toBeVisible();
+      expect(renderResult.queryByText(TEST_PROCESS_DETAIL.end)).toBeVisible();
       expect(renderResult.queryByText(TEST_PROCESS_DETAIL.exit_code)).toBeVisible();
       expect(renderResult.queryByText(TEST_PROCESS_DETAIL.user)).toBeVisible();
       expect(renderResult.queryByText(`['vi','test.txt']`)).toBeVisible();

--- a/x-pack/plugins/session_view/public/components/detail_panel_process_tab/index.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_process_tab/index.tsx
@@ -81,7 +81,7 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
       {
         title: <DetailPanelListItem>start</DetailPanelListItem>,
         description: (
-          <DetailPanelCopy textToCopy={leader.start.toISOString()}>
+          <DetailPanelCopy textToCopy={leader.start}>
             <span css={styles.description}>{leader.start}</span>
           </DetailPanelCopy>
         ),
@@ -167,7 +167,7 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
           {
             title: <DetailPanelListItem>start</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={processDetail.start.toISOString()}>
+              <DetailPanelCopy textToCopy={processDetail.start}>
                 <span css={styles.description}>{processDetail.start}</span>
               </DetailPanelCopy>
             ),
@@ -175,7 +175,7 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
           {
             title: <DetailPanelListItem>end</DetailPanelListItem>,
             description: (
-              <DetailPanelCopy textToCopy={processDetail.end.toISOString()}>
+              <DetailPanelCopy textToCopy={processDetail.end}>
                 <span css={styles.description}>{processDetail.end}</span>
               </DetailPanelCopy>
             ),

--- a/x-pack/plugins/session_view/public/components/session_view/hooks.ts
+++ b/x-pack/plugins/session_view/public/components/session_view/hooks.ts
@@ -18,7 +18,7 @@ export const useFetchSessionViewProcessEvents = (
 ) => {
   const { http } = useKibana<CoreStart>().services;
 
-  const jumpToCursor = jumpToEvent && jumpToEvent['@timestamp'].toISOString();
+  const jumpToCursor = jumpToEvent && jumpToEvent['@timestamp'];
 
   const query = useInfiniteQuery(
     'sessionViewProcessEvents',

--- a/x-pack/plugins/session_view/public/components/session_view_table_process_tree/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view_table_process_tree/index.test.tsx
@@ -33,7 +33,7 @@ const mockActionProps: ActionProps = {
   timelineId: 'test-timeline-id',
 };
 
-jest.mock('../SessionView/index.tsx', () => {
+jest.mock('../session_view/index.tsx', () => {
   return {
     SessionView: () => {
       return <div data-test-subj="SessionView">Mock</div>;
@@ -41,7 +41,7 @@ jest.mock('../SessionView/index.tsx', () => {
   };
 });
 
-jest.mock('../SessionLeaderTable/index.tsx', () => {
+jest.mock('../session_leader_table/index.tsx', () => {
   return {
     SessionLeaderTable: (props: SessionLeaderTableProps) => {
       const { onOpenSessionViewer = () => {} } = props;

--- a/x-pack/plugins/session_view/public/types.ts
+++ b/x-pack/plugins/session_view/public/types.ts
@@ -27,8 +27,8 @@ export interface EuiTabProps {
 
 export interface DetailPanelProcess {
   id: string;
-  start: Date;
-  end: Date;
+  start: string;
+  end: string;
   exit_code: number;
   user: string;
   args: string[];
@@ -43,7 +43,7 @@ export interface DetailPanelProcess {
 export interface DetailPanelProcessLeader {
   id: string;
   name: string;
-  start: Date;
+  start: string;
   entryMetaType: string;
   userName: string;
   interactive: boolean;


### PR DESCRIPTION
- Reverted `@timestamp` field to `string` type since we are getting an ISO string from ES (we might also want to consider preprocessing it to a Date when we fetch for events)
- Updated `start` and `end` fields in details panel which are related to `@timestamp`
- Fixed mock data related to `@timestamp`
- Fixed some tests related and unrelated to the type change 😈 