### PR TITLE
Add getProcessExecutableCopyText and comma-separated push

### DIFF
--- a/x-pack/plugins/session_view/public/components/detail_panel_process_tab/helpers.test.ts
+++ b/x-pack/plugins/session_view/public/components/detail_panel_process_tab/helpers.test.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { getProcessExecutableCopyText } from './helpers';
+
+describe('detail panel process tab helpers tests', () => {
+  it('getProcessExecutableCopyText works with empty array', () => {
+    const result = getProcessExecutableCopyText([]);
+    expect(result).toEqual('');
+  });
+
+  it('getProcessExecutableCopyText works with array of tuples', () => {
+    const result = getProcessExecutableCopyText([
+      ['echo', 'exec'],
+      ['echo', 'exit'],
+    ]);
+    expect(result).toEqual('echo exec, echo exit');
+  });
+
+  it('getProcessExecutableCopyText returns empty string with an  invalid array of tuples', () => {
+    const result = getProcessExecutableCopyText([['echo', 'exec'], ['echo'], ['exit']]);
+    expect(result).toEqual('');
+  });
+});

--- a/x-pack/plugins/session_view/public/components/detail_panel_process_tab/helpers.test.ts
+++ b/x-pack/plugins/session_view/public/components/detail_panel_process_tab/helpers.test.ts
@@ -20,8 +20,17 @@ describe('detail panel process tab helpers tests', () => {
     expect(result).toEqual('echo exec, echo exit');
   });
 
-  it('getProcessExecutableCopyText returns empty string with an  invalid array of tuples', () => {
-    const result = getProcessExecutableCopyText([['echo', 'exec'], ['echo'], ['exit']]);
+  it('getProcessExecutableCopyText returns empty string with an invalid array of tuples', () => {
+    // when some sub arrays only have 1 item
+    let result = getProcessExecutableCopyText([['echo', 'exec'], ['echo']]);
+    expect(result).toEqual('');
+
+    // when some sub arrays have more than two item
+    result = getProcessExecutableCopyText([
+      ['echo', 'exec'],
+      ['echo', 'exec', 'random'],
+      ['echo', 'exit'],
+    ]);
     expect(result).toEqual('');
   });
 });

--- a/x-pack/plugins/session_view/public/components/detail_panel_process_tab/helpers.ts
+++ b/x-pack/plugins/session_view/public/components/detail_panel_process_tab/helpers.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Serialize an array of executable tuples to a copyable text.
+ *
+ * @param  {String[][]} executable
+ * @return {String} serialized string with data of each executable
+ */
+export const getProcessExecutableCopyText = (executable: string[][]) => {
+  try {
+    return executable
+      .map((execTuple) => {
+        const [execCommand, eventAction] = execTuple;
+        if (!execCommand || !eventAction || execTuple.length !== 2) {
+          throw new Error();
+        }
+        return `${execCommand} ${eventAction}`;
+      })
+      .join(', ');
+  } catch (_) {
+    return '';
+  }
+};

--- a/x-pack/plugins/session_view/public/components/detail_panel_process_tab/index.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_process_tab/index.tsx
@@ -13,6 +13,7 @@ import { DetailPanelCopy } from '../detail_panel_copy';
 import { DetailPanelDescriptionList } from '../detail_panel_description_list';
 import { DetailPanelListItem } from '../detail_panel_list_item';
 import { dataOrDash } from '../../utils/data_or_dash';
+import { getProcessExecutableCopyText } from './helpers';
 import { useStyles } from './styles';
 
 interface DetailPanelProcessTabDeps {
@@ -101,32 +102,30 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
       });
     }
     listItems.push(
-      ...[
-        {
-          title: <DetailPanelListItem>user.name</DetailPanelListItem>,
-          description: (
-            <DetailPanelCopy textToCopy={leader.userName}>
-              <span css={styles.description}>{dataOrDash(leader.userName)}</span>
-            </DetailPanelCopy>
-          ),
-        },
-        {
-          title: <DetailPanelListItem>interactive</DetailPanelListItem>,
-          description: (
-            <DetailPanelCopy textToCopy={leader.interactive ? 'True' : 'False'}>
-              <span css={styles.description}>{leader.interactive ? 'True' : 'False'}</span>
-            </DetailPanelCopy>
-          ),
-        },
-        {
-          title: <DetailPanelListItem>pid</DetailPanelListItem>,
-          description: (
-            <DetailPanelCopy textToCopy={leader.pid}>
-              <span css={styles.description}>{dataOrDash(leader.pid)}</span>
-            </DetailPanelCopy>
-          ),
-        },
-      ]
+      {
+        title: <DetailPanelListItem>user.name</DetailPanelListItem>,
+        description: (
+          <DetailPanelCopy textToCopy={leader.userName}>
+            <span css={styles.description}>{dataOrDash(leader.userName)}</span>
+          </DetailPanelCopy>
+        ),
+      },
+      {
+        title: <DetailPanelListItem>interactive</DetailPanelListItem>,
+        description: (
+          <DetailPanelCopy textToCopy={leader.interactive ? 'True' : 'False'}>
+            <span css={styles.description}>{leader.interactive ? 'True' : 'False'}</span>
+          </DetailPanelCopy>
+        ),
+      },
+      {
+        title: <DetailPanelListItem>pid</DetailPanelListItem>,
+        description: (
+          <DetailPanelCopy textToCopy={leader.pid}>
+            <span css={styles.description}>{dataOrDash(leader.pid)}</span>
+          </DetailPanelCopy>
+        ),
+      }
     );
     // Only include entry_meta.source.ip for entry leader
     if (idx === 0) {
@@ -210,12 +209,7 @@ export const DetailPanelProcessTab = ({ processDetail }: DetailPanelProcessTabDe
             title: <DetailPanelListItem>executable</DetailPanelListItem>,
             description: (
               <DetailPanelCopy
-                textToCopy={processDetail.executable
-                  .map((execTuple) => {
-                    const [executable, eventAction] = execTuple;
-                    return `${executable} ${eventAction}`;
-                  })
-                  .join(', ')}
+                textToCopy={getProcessExecutableCopyText(processDetail.executable)}
                 display="block"
               >
                 {processDetail.executable.map((execTuple, idx) => {


### PR DESCRIPTION
- moved the logic to get `textToCopy` for `process.executable` to `getProcessExecutableCopyText`
- use comma separated push for leader process fields