### PR TITLE
CI Text fixes / prefixes

### DIFF
--- a/x-pack/plugins/session_view/public/components/detail_panel_accordion/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_accordion/index.test.tsx
@@ -34,7 +34,7 @@ describe('DetailPanelAccordion component', () => {
         <DetailPanelAccordion id={TEST_ID} listItems={TEST_LIST_ITEM} title={TEST_TITLE} />
       );
 
-      expect(renderResult.queryByTestId('sessionViewer:detail-panel-accordion')).toBeVisible();
+      expect(renderResult.queryByTestId('sessionView:detail-panel-accordion')).toBeVisible();
     });
 
     it('should render acoordion with tooltip', async () => {
@@ -47,9 +47,9 @@ describe('DetailPanelAccordion component', () => {
         />
       );
 
-      expect(renderResult.queryByTestId('sessionViewer:detail-panel-accordion')).toBeVisible();
+      expect(renderResult.queryByTestId('sessionView:detail-panel-accordion')).toBeVisible();
       expect(
-        renderResult.queryByTestId('sessionViewer:detail-panel-accordion-tooltip')
+        renderResult.queryByTestId('sessionView:detail-panel-accordion-tooltip')
       ).toBeVisible();
     });
 
@@ -65,9 +65,9 @@ describe('DetailPanelAccordion component', () => {
         />
       );
 
-      expect(renderResult.queryByTestId('sessionViewer:detail-panel-accordion')).toBeVisible();
+      expect(renderResult.queryByTestId('sessionView:detail-panel-accordion')).toBeVisible();
       const extraActionButton = renderResult.getByTestId(
-        'sessionViewer:detail-panel-accordion-action'
+        'sessionView:detail-panel-accordion-action'
       );
       expect(extraActionButton).toHaveTextContent(ACTION_TEXT);
       extraActionButton.click();

--- a/x-pack/plugins/session_view/public/components/detail_panel_accordion/index.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_accordion/index.tsx
@@ -49,7 +49,7 @@ export const DetailPanelAccordion = ({
             <span>{title}</span>
           </EuiFlexItem>
           {tooltipContent && (
-            <EuiFlexItem grow={false} data-test-subj="sessionViewer:detail-panel-accordion-tooltip">
+            <EuiFlexItem grow={false} data-test-subj="sessionView:detail-panel-accordion-tooltip">
               <EuiIconTip content={tooltipContent} />
             </EuiFlexItem>
           )}
@@ -61,14 +61,14 @@ export const DetailPanelAccordion = ({
             size="s"
             color="primary"
             onClick={onExtraActionClick}
-            data-test-subj="sessionViewer:detail-panel-accordion-action"
+            data-test-subj="sessionView:detail-panel-accordion-action"
           >
             {extraActionTitle}
           </EuiButtonEmpty>
         ) : null
       }
       css={styles.accordion}
-      data-test-subj="sessionViewer:detail-panel-accordion"
+      data-test-subj="sessionView:detail-panel-accordion"
     >
       <DetailPanelDescriptionList listItems={listItems} />
     </EuiAccordion>

--- a/x-pack/plugins/session_view/public/components/detail_panel_description_list/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_description_list/index.test.tsx
@@ -39,9 +39,7 @@ describe('DetailPanelDescriptionList component', () => {
         <DetailPanelDescriptionList listItems={TEST_LIST_ITEM} />
       );
 
-      expect(
-        renderResult.queryByTestId('sessionViewer:detail-panel-description-list')
-      ).toBeVisible();
+      expect(renderResult.queryByTestId('sessionView:detail-panel-description-list')).toBeVisible();
 
       // check list items are rendered
       expect(renderResult.queryByText(TEST_FIRST_TITLE)).toBeVisible();

--- a/x-pack/plugins/session_view/public/components/detail_panel_description_list/index.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_description_list/index.tsx
@@ -27,7 +27,7 @@ export const DetailPanelDescriptionList = ({ listItems }: DetailPanelDescription
       css={styles.descriptionList}
       titleProps={{ style: styles.tabListTitle }}
       descriptionProps={{ style: styles.tabListDescription }}
-      data-test-subj="sessionViewer:detail-panel-description-list"
+      data-test-subj="sessionView:detail-panel-description-list"
     />
   );
 };

--- a/x-pack/plugins/session_view/public/components/detail_panel_host_tab/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_host_tab/index.test.tsx
@@ -68,7 +68,7 @@ describe('DetailPanelHostTab component', () => {
 
       // expand host os accordion
       renderResult
-        .queryByTestId('sessionViewer:detail-panel-accordion')
+        .queryByTestId('sessionView:detail-panel-accordion')
         ?.querySelector('button')
         ?.click();
       expect(renderResult.queryByText('os.family')).toBeVisible();

--- a/x-pack/plugins/session_view/public/components/detail_panel_list_item/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_list_item/index.test.tsx
@@ -13,9 +13,9 @@ import { DetailPanelListItem } from './index';
 const TEST_STRING = 'item title';
 const TEST_CHILD = <span>{TEST_STRING}</span>;
 const TEST_COPY_STRING = 'test copy button';
-const BUTTON_TEST_ID = 'test-copy-button';
+const BUTTON_TEST_ID = 'sessionView:test-copy-button';
 const TEST_COPY = <button data-test-subj={BUTTON_TEST_ID}>{TEST_COPY_STRING}</button>;
-const LIST_ITEM_TEST_ID = 'sessionViewer:detail-panel-list-item';
+const LIST_ITEM_TEST_ID = 'sessionView:detail-panel-list-item';
 const WAIT_TIMEOUT = 500;
 
 describe('DetailPanelListItem component', () => {

--- a/x-pack/plugins/session_view/public/components/detail_panel_list_item/index.tsx
+++ b/x-pack/plugins/session_view/public/components/detail_panel_list_item/index.tsx
@@ -43,7 +43,7 @@ export const DetailPanelListItem = ({
   }
 
   return (
-    <EuiText {...props} data-test-subj="sessionViewer:detail-panel-list-item">
+    <EuiText {...props} data-test-subj="sessionView:detail-panel-list-item">
       {children}
       {isHovered && copy}
     </EuiText>

--- a/x-pack/plugins/session_view/public/components/process_tree/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree/index.test.tsx
@@ -34,8 +34,8 @@ describe('ProcessTree component', () => {
           onProcessSelected={jest.fn()}
         />
       );
-      expect(renderResult.queryByTestId('sessionViewProcessTree')).toBeTruthy();
-      expect(renderResult.queryAllByTestId('processTreeNode')).toBeTruthy();
+      expect(renderResult.queryByTestId('sessionView:sessionViewProcessTree')).toBeTruthy();
+      expect(renderResult.queryAllByTestId('sessionView:processTreeNode')).toBeTruthy();
     });
 
     it('should insert a DOM element used to highlight a process when selectedProcess is set', () => {
@@ -54,6 +54,9 @@ describe('ProcessTree component', () => {
           onProcessSelected={jest.fn()}
         />
       );
+
+      // click on view more button
+      renderResult.getByTestId('sessionView:processTreeNodeChildProcessesButton').click();
 
       expect(
         renderResult

--- a/x-pack/plugins/session_view/public/components/process_tree/index.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree/index.tsx
@@ -155,7 +155,11 @@ export const ProcessTree = ({
   }
 
   return (
-    <div ref={scrollerRef} css={styles.scroller} data-test-subj="sessionViewProcessTree">
+    <div
+      ref={scrollerRef}
+      css={styles.scroller}
+      data-test-subj="sessionView:sessionViewProcessTree"
+    >
       {hasPreviousPage &&
         renderLoadMoreButton(
           <FormattedMessage id="xpack.sessionView.loadPrevious" defaultMessage="Load previous" />,

--- a/x-pack/plugins/session_view/public/components/process_tree_alerts/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree_alerts/index.test.tsx
@@ -23,13 +23,13 @@ describe('ProcessTreeAlerts component', () => {
     it('should return null if no alerts', async () => {
       renderResult = mockedContext.render(<ProcessTreeAlerts alerts={[]} />);
 
-      expect(renderResult.queryByTestId('sessionViewAlertDetails')).toBeNull();
+      expect(renderResult.queryByTestId('sessionView:sessionViewAlertDetails')).toBeNull();
     });
 
     it('should return an array of alert details', async () => {
       renderResult = mockedContext.render(<ProcessTreeAlerts alerts={mockAlerts} />);
 
-      expect(renderResult.queryByTestId('sessionViewAlertDetails')).toBeTruthy();
+      expect(renderResult.queryByTestId('sessionView:sessionViewAlertDetails')).toBeTruthy();
       mockAlerts.forEach((alert) => {
         if (!alert.kibana) {
           return;
@@ -37,8 +37,12 @@ describe('ProcessTreeAlerts component', () => {
         const { uuid, rule, original_event: event, workflow_status: status } = alert.kibana.alert;
         const { name, query, severity } = rule;
 
-        expect(renderResult.queryByTestId(`sessionViewAlertDetail-${uuid}`)).toBeTruthy();
-        expect(renderResult.queryByTestId(`sessionViewAlertDetailViewRule-${uuid}`)).toBeTruthy();
+        expect(
+          renderResult.queryByTestId(`sessionView:sessionViewAlertDetail-${uuid}`)
+        ).toBeTruthy();
+        expect(
+          renderResult.queryByTestId(`sessionView:sessionViewAlertDetailViewRule-${uuid}`)
+        ).toBeTruthy();
         expect(renderResult.queryAllByText(new RegExp(event.action, 'i')).length).toBeTruthy();
         expect(renderResult.queryAllByText(new RegExp(status, 'i')).length).toBeTruthy();
         expect(renderResult.queryAllByText(new RegExp(name, 'i')).length).toBeTruthy();

--- a/x-pack/plugins/session_view/public/components/process_tree_alerts/index.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree_alerts/index.tsx
@@ -46,7 +46,7 @@ export function ProcessTreeAlerts({ alerts }: ProcessTreeAlertsDeps) {
     const isLastAlert = index < alerts.length - 1;
 
     return (
-      <EuiText key={uuid} size="s" data-test-subj={`sessionViewAlertDetail-${uuid}`}>
+      <EuiText key={uuid} size="s" data-test-subj={`sessionView:sessionViewAlertDetail-${uuid}`}>
         <EuiFlexGroup>
           <EuiFlexItem>
             <h6>
@@ -81,7 +81,7 @@ export function ProcessTreeAlerts({ alerts }: ProcessTreeAlertsDeps) {
               <EuiButton
                 size="s"
                 href={getRuleUrl(alert)}
-                data-test-subj={`sessionViewAlertDetailViewRule-${uuid}`}
+                data-test-subj={`sessionView:sessionViewAlertDetailViewRule-${uuid}`}
               >
                 <FormattedMessage id="xpack.sessionView.viewRule" defaultMessage="View rule" />
               </EuiButton>
@@ -98,7 +98,7 @@ export function ProcessTreeAlerts({ alerts }: ProcessTreeAlertsDeps) {
   };
 
   return (
-    <div css={styles.container} data-test-subj="sessionViewAlertDetails">
+    <div css={styles.container} data-test-subj="sessionView:sessionViewAlertDetails">
       {alerts.map(renderAlertDetails)}
     </div>
   );

--- a/x-pack/plugins/session_view/public/components/process_tree_node/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree_node/index.test.tsx
@@ -28,7 +28,7 @@ describe('ProcessTreeNode component', () => {
     it('should render given a valid process', async () => {
       renderResult = mockedContext.render(<ProcessTreeNode process={processMock} />);
 
-      expect(renderResult.queryByTestId('processTreeNode')).toBeTruthy();
+      expect(renderResult.queryByTestId('sessionView:processTreeNode')).toBeTruthy();
     });
 
     it('should have an alternate rendering for a session leader', async () => {
@@ -66,7 +66,7 @@ describe('ProcessTreeNode component', () => {
 
       renderResult = mockedContext.render(<ProcessTreeNode process={userEnteredProcessMock} />);
 
-      expect(renderResult.queryByTestId('processTreeNodeUserIcon')).toBeTruthy();
+      expect(renderResult.queryByTestId('sessionView:processTreeNodeUserIcon')).toBeTruthy();
     });
 
     it('renders Exec icon for executed process', async () => {
@@ -77,7 +77,7 @@ describe('ProcessTreeNode component', () => {
 
       renderResult = mockedContext.render(<ProcessTreeNode process={executedProcessMock} />);
 
-      expect(renderResult.queryByTestId('processTreeNodeExecIcon')).toBeTruthy();
+      expect(renderResult.queryByTestId('sessionView:processTreeNodeExecIcon')).toBeTruthy();
     });
 
     it('renders Root Escalation flag properly', async () => {
@@ -104,7 +104,9 @@ describe('ProcessTreeNode component', () => {
 
       renderResult = mockedContext.render(<ProcessTreeNode process={rootEscalationProcessMock} />);
 
-      expect(renderResult.queryByTestId('processTreeNodeRootEscalationFlag')).toBeTruthy();
+      expect(
+        renderResult.queryByTestId('sessionView:processTreeNodeRootEscalationFlag')
+      ).toBeTruthy();
     });
 
     it('executes callback function when user Clicks', async () => {
@@ -114,7 +116,7 @@ describe('ProcessTreeNode component', () => {
         <ProcessTreeNode process={processMock} onProcessSelected={onProcessSelected} />
       );
 
-      userEvent.click(renderResult.getByTestId('processTreeNodeRow'));
+      userEvent.click(renderResult.getByTestId('sessionView:processTreeNodeRow'));
       expect(onProcessSelected).toHaveBeenCalled();
     });
 
@@ -130,7 +132,7 @@ describe('ProcessTreeNode component', () => {
       // @ts-ignore
       windowGetSelectionSpy.mockImplementation(() => ({ type: 'Range' }));
 
-      userEvent.click(renderResult.getByTestId('processTreeNodeRow'));
+      userEvent.click(renderResult.getByTestId('sessionView:processTreeNodeRow'));
       expect(onProcessSelected).not.toHaveBeenCalled();
 
       // cleanup
@@ -149,9 +151,9 @@ describe('ProcessTreeNode component', () => {
           <ProcessTreeNode process={sessionViewAlertProcessMock} />
         );
         userEvent.click(renderResult.getByTestId('processTreeNodeAlertButton'));
-        expect(renderResult.queryByTestId('sessionViewAlertDetails')).toBeTruthy();
+        expect(renderResult.queryByTestId('sessionView:sessionViewAlertDetails')).toBeTruthy();
         userEvent.click(renderResult.getByTestId('processTreeNodeAlertButton'));
-        expect(renderResult.queryByTestId('sessionViewAlertDetails')).toBeFalsy();
+        expect(renderResult.queryByTestId('sessionView:sessionViewAlertDetails')).toBeFalsy();
       });
     });
     describe('Child processes', () => {
@@ -163,7 +165,9 @@ describe('ProcessTreeNode component', () => {
 
         renderResult = mockedContext.render(<ProcessTreeNode process={processMockWithChildren} />);
 
-        expect(renderResult.queryByTestId('processTreeNodeChildProcessesButton')).toBeTruthy();
+        expect(
+          renderResult.queryByTestId('sessionView:processTreeNodeChildProcessesButton')
+        ).toBeTruthy();
       });
       it('toggle Child processes nodes when Child processes button is clicked', async () => {
         const processMockWithChildren: typeof processMock = {
@@ -173,13 +177,17 @@ describe('ProcessTreeNode component', () => {
 
         renderResult = mockedContext.render(<ProcessTreeNode process={processMockWithChildren} />);
 
-        expect(renderResult.getAllByTestId('processTreeNode')).toHaveLength(1);
+        expect(renderResult.getAllByTestId('sessionView:processTreeNode')).toHaveLength(1);
 
-        userEvent.click(renderResult.getByTestId('processTreeNodeChildProcessesButton'));
-        expect(renderResult.getAllByTestId('processTreeNode')).toHaveLength(2);
+        userEvent.click(
+          renderResult.getByTestId('sessionView:processTreeNodeChildProcessesButton')
+        );
+        expect(renderResult.getAllByTestId('sessionView:processTreeNode')).toHaveLength(2);
 
-        userEvent.click(renderResult.getByTestId('processTreeNodeChildProcessesButton'));
-        expect(renderResult.getAllByTestId('processTreeNode')).toHaveLength(1);
+        userEvent.click(
+          renderResult.getByTestId('sessionView:processTreeNodeChildProcessesButton')
+        );
+        expect(renderResult.getAllByTestId('sessionView:processTreeNode')).toHaveLength(1);
       });
     });
     describe('Search', () => {
@@ -189,9 +197,9 @@ describe('ProcessTreeNode component', () => {
 
         renderResult = mockedContext.render(<ProcessTreeNode process={processMock} />);
 
-        expect(renderResult.getByTestId('processNodeSearchHighlight').textContent).toEqual(
-          '/vagrant'
-        );
+        expect(
+          renderResult.getByTestId('sessionView:processNodeSearchHighlight').textContent
+        ).toEqual('/vagrant');
       });
     });
   });

--- a/x-pack/plugins/session_view/public/components/process_tree_node/index.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree_node/index.tsx
@@ -59,7 +59,7 @@ export function ProcessTreeNode({
 
       if (text) {
         const html = text.replace(regex, (match) => {
-          return `<span data-test-subj="processNodeSearchHighlight" style="${styles.searchHighlight}">${match}</span>`;
+          return `<span data-test-subj="sessionView:processNodeSearchHighlight" style="${styles.searchHighlight}">${match}</span>`;
         });
 
         // eslint-disable-next-line no-unsanitized/property
@@ -131,7 +131,7 @@ export function ProcessTreeNode({
               key="group-leaders-only-button"
               css={styles.getButtonStyle(ButtonType.children)}
               onClick={onShowGroupLeaderOnlyClick}
-              data-test-subj="processTreeNodeChildProcessesButton"
+              data-test-subj="sessionView:processTreeNodeChildProcessesButton"
             >
               <FormattedMessage
                 id="xpack.sessionView.plusCountMore"
@@ -155,7 +155,7 @@ export function ProcessTreeNode({
           key="child-processes-button"
           css={styles.getButtonStyle(ButtonType.children)}
           onClick={() => setChildrenExpanded(!childrenExpanded)}
-          data-test-subj="processTreeNodeChildProcessesButton"
+          data-test-subj="sessionView:processTreeNodeChildProcessesButton"
         >
           <FormattedMessage
             id="xpack.sessionView.childProcesses"
@@ -233,13 +233,13 @@ export function ProcessTreeNode({
       <span>
         {process.isUserEntered() && (
           <EuiIcon
-            data-test-subj="processTreeNodeUserIcon"
+            data-test-subj="sessionView:processTreeNodeUserIcon"
             css={styles.userEnteredIcon}
             type="user"
           />
         )}
         {hasExec ? (
-          <EuiIcon data-test-subj="processTreeNodeExecIcon" type="console" />
+          <EuiIcon data-test-subj="sessionView:processTreeNodeExecIcon" type="console" />
         ) : (
           <EuiIcon type="branch" />
         )}
@@ -255,7 +255,7 @@ export function ProcessTreeNode({
     if (user.name === 'root' && user.id !== parent.user.id) {
       return (
         <EuiButton
-          data-test-subj="processTreeNodeRootEscalationFlag"
+          data-test-subj="sessionView:processTreeNodeRootEscalationFlag"
           css={styles.getButtonStyle(ButtonType.userChanged)}
         >
           <FormattedMessage
@@ -288,10 +288,14 @@ export function ProcessTreeNode({
         data-id={id}
         key={id + searchMatched}
         css={styles.processNode}
-        data-test-subj="processTreeNode"
+        data-test-subj="sessionView:processTreeNode"
       >
         {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
-        <div data-test-subj="processTreeNodeRow" css={styles.wrapper} onClick={onProcessClicked}>
+        <div
+          data-test-subj="sessionView:processTreeNodeRow"
+          css={styles.wrapper}
+          onClick={onProcessClicked}
+        >
           {isSessionLeader ? renderSessionLeader() : renderProcess()}
           {renderRootEscalation()}
           {renderButtons()}

--- a/x-pack/plugins/session_view/public/components/session_view/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view/index.test.tsx
@@ -38,13 +38,15 @@ describe('SessionView component', () => {
       it('should show the Empty message', async () => {
         render();
         await waitForApiCall();
-        expect(renderResult.getByTestId('sessionViewProcessEventsEmpty')).toBeTruthy();
+        expect(renderResult.getByTestId('sessionView:sessionViewProcessEventsEmpty')).toBeTruthy();
       });
 
       it('should not display the search bar', async () => {
         render();
         await waitForApiCall();
-        expect(renderResult.queryByTestId('sessionViewProcessEventsSearch')).toBeFalsy();
+        expect(
+          renderResult.queryByTestId('sessionView:sessionViewProcessEventsSearch')
+        ).toBeFalsy();
       });
     });
 
@@ -62,28 +64,28 @@ describe('SessionView component', () => {
         await waitForApiCall();
 
         // see if loader is present
-        expect(renderResult.getByTestId('sectionLoading')).toBeTruthy();
+        expect(renderResult.getByText('Loading session…')).toBeTruthy();
 
         // release the request
         releaseApiResponse!(mockedApi);
 
         //  check the loader is gone
-        await waitForElementToBeRemoved(renderResult.getByTestId('sectionLoading'));
+        await waitForElementToBeRemoved(renderResult.getByText('Loading session…'));
       });
 
       it('should display the search bar', async () => {
         render();
         await waitForApiCall();
-        expect(renderResult.getByTestId('sessionViewProcessEventsSearch')).toBeTruthy();
+        expect(renderResult.getByTestId('sessionView:sessionViewProcessEventsSearch')).toBeTruthy();
       });
 
       it('should show items on the list, and auto selects session leader', async () => {
         render();
         await waitForApiCall();
 
-        expect(renderResult.getAllByTestId('processTreeNode')).toBeTruthy();
+        expect(renderResult.getAllByTestId('sessionView:processTreeNode')).toBeTruthy();
 
-        const selectionArea = renderResult.queryByTestId('processTreeSelectionArea');
+        const selectionArea = renderResult.queryByTestId('sessionView:processTreeSelectionArea');
 
         expect(selectionArea?.parentElement?.getAttribute('data-id')).toEqual('test-entity-id');
       });

--- a/x-pack/plugins/session_view/public/components/session_view/index.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view/index.tsx
@@ -60,7 +60,7 @@ export const SessionView = ({ sessionEntityId, height, jumpToEvent }: SessionVie
   const renderNoData = () => {
     return (
       <EuiEmptyPrompt
-        data-test-subj="sessionViewProcessEventsEmpty"
+        data-test-subj="sessionView:sessionViewProcessEventsEmpty"
         title={
           <h2>
             <FormattedMessage
@@ -172,7 +172,10 @@ export const SessionView = ({ sessionEntityId, height, jumpToEvent }: SessionVie
   return (
     <>
       <EuiFlexGroup>
-        <EuiFlexItem data-test-subj="sessionViewProcessEventsSearch" css={{ position: 'relative' }}>
+        <EuiFlexItem
+          data-test-subj="sessionView:sessionViewProcessEventsSearch"
+          css={{ position: 'relative' }}
+        >
           <SessionViewSearchBar
             searchQuery={searchQuery}
             setSearchQuery={setSearchQuery}

--- a/x-pack/plugins/session_view/public/components/session_view_search_bar/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view_search_bar/index.test.tsx
@@ -34,7 +34,7 @@ describe('SessionViewSearchBar component', () => {
       />
     );
 
-    const searchInput = renderResult.getByTestId('searchInput').querySelector('input');
+    const searchInput = renderResult.getByTestId('sessionView:searchInput').querySelector('input');
 
     expect(searchInput?.value).toEqual('ls');
 
@@ -64,7 +64,7 @@ describe('SessionViewSearchBar component', () => {
       />
     );
 
-    const searchPagination = renderResult.getByTestId('searchPagination');
+    const searchPagination = renderResult.getByTestId('sessionView:searchPagination');
     expect(searchPagination).toBeTruthy();
 
     const paginationTextClass = '.euiPagination__compressedText';
@@ -73,7 +73,7 @@ describe('SessionViewSearchBar component', () => {
     userEvent.click(renderResult.getByTestId('pagination-button-next'));
     expect(searchPagination.querySelector(paginationTextClass)?.textContent).toEqual('2 of 3');
 
-    const searchInput = renderResult.getByTestId('searchInput').querySelector('input');
+    const searchInput = renderResult.getByTestId('sessionView:searchInput').querySelector('input');
 
     if (searchInput) {
       userEvent.type(searchInput, ' -la');

--- a/x-pack/plugins/session_view/public/components/session_view_search_bar/index.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view_search_bar/index.tsx
@@ -44,7 +44,7 @@ export const SessionViewSearchBar = ({
     if (searchResults?.length) {
       return (
         <EuiPagination
-          data-test-subj="searchPagination"
+          data-test-subj="sessionView:searchPagination"
           css={styles.pagination}
           pageCount={searchResults.length}
           activePage={selectedResult}
@@ -64,7 +64,7 @@ export const SessionViewSearchBar = ({
   }, [searchResults, setSelectedProcess, selectedResult]);
 
   return (
-    <div data-test-subj="searchInput" css={{ position: 'relative' }}>
+    <div data-test-subj="sessionView:searchInput" css={{ position: 'relative' }}>
       <EuiSearchBar query={searchQuery} onChange={onSearch} />
       {renderSearchResults()}
     </div>

--- a/x-pack/plugins/session_view/public/components/session_view_table_process_tree/index.test.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view_table_process_tree/index.test.tsx
@@ -36,7 +36,7 @@ const mockActionProps: ActionProps = {
 jest.mock('../session_view/index.tsx', () => {
   return {
     SessionView: () => {
-      return <div data-test-subj="SessionView">Mock</div>;
+      return <div data-test-subj="sessionView:SessionView">Mock</div>;
     },
   };
 });
@@ -48,7 +48,7 @@ jest.mock('../session_leader_table/index.tsx', () => {
       return (
         // eslint-disable-next-line jsx-a11y/click-events-have-key-events
         <div
-          data-test-subj="SessionLeaderTable"
+          data-test-subj="sessionView:SessionLeaderTable"
           onClick={() => onOpenSessionViewer(mockActionProps)}
         >
           Mock
@@ -84,35 +84,35 @@ describe('SessionViewTableProcessTree component', () => {
 
     it('Renders session leader table initially', async () => {
       renderResult = mockedContext.render(<SessionViewTableProcessTree />);
-      expect(renderResult.queryByTestId('SessionLeaderTable')).toBeTruthy();
-      expect(renderResult.queryByTestId('SessionView')).toBeNull();
+      expect(renderResult.queryByTestId('sessionView:SessionLeaderTable')).toBeTruthy();
+      expect(renderResult.queryByTestId('sessionView:SessionView')).toBeNull();
     });
 
     it('Switches to session view when the user picks a session', async () => {
       renderResult = mockedContext.render(<SessionViewTableProcessTree />);
-      const sessionLeaderTable = renderResult.getByTestId('SessionLeaderTable');
+      const sessionLeaderTable = renderResult.getByTestId('sessionView:SessionLeaderTable');
       fireEvent.click(sessionLeaderTable);
       await waitForApiCall();
 
       // Now that we fetched the entity id, session view should be visible
-      expect(renderResult.queryByTestId('SessionView')).toBeTruthy();
-      expect(renderResult.queryByTestId('SessionLeaderTable')).toBeNull();
+      expect(renderResult.queryByTestId('sessionView:SessionView')).toBeTruthy();
+      expect(renderResult.queryByTestId('sessionView:SessionLeaderTable')).toBeNull();
     });
 
     it('Close button works', async () => {
       renderResult = mockedContext.render(<SessionViewTableProcessTree />);
-      const sessionLeaderTable = renderResult.getByTestId('SessionLeaderTable');
+      const sessionLeaderTable = renderResult.getByTestId('sessionView:SessionLeaderTable');
       fireEvent.click(sessionLeaderTable);
       await waitForApiCall();
 
-      expect(renderResult.queryByTestId('SessionView')).toBeTruthy();
-      expect(renderResult.queryByTestId('SessionLeaderTable')).toBeNull();
+      expect(renderResult.queryByTestId('sessionView:SessionView')).toBeTruthy();
+      expect(renderResult.queryByTestId('sessionView:SessionLeaderTable')).toBeNull();
 
-      const closeButton = renderResult.getByTestId('session-view-close-button');
+      const closeButton = renderResult.getByTestId('sessionView:session-view-close-button');
       fireEvent.click(closeButton);
 
-      expect(renderResult.queryByTestId('SessionLeaderTable')).toBeTruthy();
-      expect(renderResult.queryByTestId('SessionView')).toBeNull();
+      expect(renderResult.queryByTestId('sessionView:SessionLeaderTable')).toBeTruthy();
+      expect(renderResult.queryByTestId('sessionView:SessionView')).toBeNull();
     });
   });
 });

--- a/x-pack/plugins/session_view/public/components/session_view_table_process_tree/index.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view_table_process_tree/index.tsx
@@ -67,7 +67,7 @@ export const SessionViewTableProcessTreeContent = (props: SessionViewTableProces
           iconSide="left"
           iconType="cross"
           onClick={handleCloseProcessTree}
-          data-test-subj="session-view-close-button"
+          data-test-subj="sessionView:session-view-close-button"
         >
           Close session viewer
         </EuiButtonEmpty>


### PR DESCRIPTION
### Summary

- Fixed some tests failing on the last CI Build
- Updated tons of test id prefixes to add `sessionView:` as stated on the PR comments
- Update some `sessionViewer` prefixes to `sessionView`, as it is the plugin Id

![image](https://user-images.githubusercontent.com/19270322/155569554-813258b3-d3d4-45c8-9950-5ba9363c6e39.png)
