### PR TITLE
Fix session leader parent getting overwritten

### DIFF
--- a/x-pack/plugins/session_view/public/components/process_tree/hooks.ts
+++ b/x-pack/plugins/session_view/public/components/process_tree/hooks.ts
@@ -194,6 +194,7 @@ export const useProcessTree = ({ sessionEntityId, data, searchQuery }: UseProces
     fakeLeaderEvent.process = {
       ...fakeLeaderEvent.process,
       ...fakeLeaderEvent.process.entry_leader,
+      parent: fakeLeaderEvent.process.parent,
     };
     sessionLeaderProcess.events.push(fakeLeaderEvent);
   }


### PR DESCRIPTION
- Session leader's parent field was missing some data since it was getting overwritten by `entry_leader.parent` in `useProcessTree`
- side note: it was also causing WSOD when opening detail panel with session leader selected 👀 