### PR TITLE
Fix to selectedProcess getting set to null unexpectedly.

### DIFF
--- a/x-pack/plugins/session_view/public/components/session_view/index.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view/index.tsx
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import {
   EuiEmptyPrompt,
   EuiButton,
@@ -37,9 +37,9 @@ export const SessionView = ({ sessionEntityId, height, jumpToEvent }: SessionVie
 
   const styles = useStyles({ height });
 
-  const onProcessSelected = (process: Process) => {
+  const onProcessSelected = useCallback((process: Process) => {
     setSelectedProcess(process);
-  };
+  }, []);
 
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<Process[] | null>(null);
@@ -95,7 +95,7 @@ export const SessionView = ({ sessionEntityId, height, jumpToEvent }: SessionVie
           <SessionViewSearchBar
             searchQuery={searchQuery}
             setSearchQuery={setSearchQuery}
-            setSelectedProcess={setSelectedProcess}
+            onProcessSelected={onProcessSelected}
             searchResults={searchResults}
           />
         </EuiFlexItem>

--- a/x-pack/plugins/session_view/public/components/session_view/index.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view/index.tsx
@@ -190,7 +190,9 @@ export const SessionView = ({ sessionEntityId, height, jumpToEvent }: SessionVie
                 </EuiResizablePanel>
               </>
             ) : (
-              <>{/* Returning an empty element here (instead of false) to avoid a bug in EuiResizableContainer */}</>
+              <>
+                {/* Returning an empty element here (instead of false) to avoid a bug in EuiResizableContainer */}
+              </>
             )}
           </>
         )}

--- a/x-pack/plugins/session_view/public/components/session_view_search_bar/index.tsx
+++ b/x-pack/plugins/session_view/public/components/session_view_search_bar/index.tsx
@@ -14,7 +14,7 @@ interface SessionViewSearchBarDeps {
   searchQuery: string;
   setSearchQuery(val: string): void;
   searchResults: Process[] | null;
-  setSelectedProcess(process: Process): void;
+  onProcessSelected(process: Process): void;
 }
 
 /**
@@ -23,7 +23,7 @@ interface SessionViewSearchBarDeps {
 export const SessionViewSearchBar = ({
   searchQuery,
   setSearchQuery,
-  setSelectedProcess,
+  onProcessSelected,
   searchResults,
 }: SessionViewSearchBarDeps) => {
   const styles = useStyles();
@@ -44,9 +44,11 @@ export const SessionViewSearchBar = ({
     if (searchResults) {
       const process = searchResults[selectedResult];
 
-      setSelectedProcess(process);
+      if (process) {
+        onProcessSelected(process);
+      }
     }
-  }, [searchResults, setSelectedProcess, selectedResult]);
+  }, [searchResults, onProcessSelected, selectedResult]);
 
   const showPagination = !!searchResults?.length;
 


### PR DESCRIPTION
The search bar was calling setSelectedProcess with a null process.

Also wrapped the function in a useCallback to avoid running useEffect unnessesarily.