### PR TITLE
Split renderButtons() and renderedAlerts() methods into separated components

### DIFF
--- a/x-pack/plugins/session_view/public/components/process_tree_alerts/index.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree_alerts/index.tsx
@@ -24,83 +24,79 @@ interface ProcessTreeAlertsDeps {
   alerts: ProcessEvent[];
 }
 
-export function ProcessTreeAlerts({ alerts }: ProcessTreeAlertsDeps) {
-  const styles = useStyles();
+const getRuleUrl = (alert: ProcessEvent, http: CoreStart['http']) => {
+  return http.basePath.prepend(`/app/security/rules/id/${alert.kibana?.alert.rule.uuid}`);
+};
+
+const ProcessTreeAlert = ({ alert }: { alert: ProcessEvent }) => {
   const { http } = useKibana<CoreStart>().services;
 
-  const renderedAlerts = useMemo(() => {
-    const getRuleUrl = (alert: ProcessEvent) => {
-      return http.basePath.prepend(`/app/security/rules/id/${alert.kibana?.alert.rule.uuid}`);
-    };
+  if (!alert.kibana) {
+    return null;
+  }
 
-    return alerts.map((alert: ProcessEvent, index: number) => {
-      if (!alert.kibana) {
-        return null;
-      }
+  const { uuid, rule, original_event: event, workflow_status: status } = alert.kibana.alert;
+  const { name, query, severity } = rule;
 
-      const { uuid, rule, original_event: event, workflow_status: status } = alert.kibana.alert;
-      const { name, query, severity } = rule;
-      const isLastAlert = index < alerts.length - 1;
+  return (
+    <EuiText key={uuid} size="s" data-test-subj={`sessionView:sessionViewAlertDetail-${uuid}`}>
+      <EuiFlexGroup>
+        <EuiFlexItem>
+          <h6>
+            <FormattedMessage id="xpack.sessionView.rule" defaultMessage="Rule" />
+          </h6>
+          {name}
+          <h6>
+            <FormattedMessage id="xpack.sessionView.query" defaultMessage="Query" />
+          </h6>
+          {query}
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <h6>
+            <FormattedMessage id="xpack.sessionView.severity" defaultMessage="Severity" />
+          </h6>
+          {severity}
+          <h6>
+            <FormattedMessage
+              id="xpack.sessionView.workflowStatus"
+              defaultMessage="Workflow status"
+            />
+          </h6>
+          {status}
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <h6>
+            <FormattedMessage id="xpack.sessionView.action" defaultMessage="Action" />
+          </h6>
+          {event.action}
+          <EuiSpacer />
+          <div>
+            <EuiButton
+              size="s"
+              href={getRuleUrl(alert, http)}
+              data-test-subj={`sessionView:sessionViewAlertDetailViewRule-${uuid}`}
+            >
+              <FormattedMessage id="xpack.sessionView.viewRule" defaultMessage="View rule" />
+            </EuiButton>
+          </div>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiText>
+  );
+};
 
-      return (
-        <EuiText key={uuid} size="s" data-test-subj={`sessionView:sessionViewAlertDetail-${uuid}`}>
-          <EuiFlexGroup>
-            <EuiFlexItem>
-              <h6>
-                <FormattedMessage id="xpack.sessionView.rule" defaultMessage="Rule" />
-              </h6>
-              {name}
-              <h6>
-                <FormattedMessage id="xpack.sessionView.query" defaultMessage="Query" />
-              </h6>
-              {query}
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <h6>
-                <FormattedMessage id="xpack.sessionView.severity" defaultMessage="Severity" />
-              </h6>
-              {severity}
-              <h6>
-                <FormattedMessage
-                  id="xpack.sessionView.workflowStatus"
-                  defaultMessage="Workflow status"
-                />
-              </h6>
-              {status}
-            </EuiFlexItem>
-            <EuiFlexItem>
-              <h6>
-                <FormattedMessage id="xpack.sessionView.action" defaultMessage="Action" />
-              </h6>
-              {event.action}
-              <EuiSpacer />
-              <div>
-                <EuiButton
-                  size="s"
-                  href={getRuleUrl(alert)}
-                  data-test-subj={`sessionView:sessionViewAlertDetailViewRule-${uuid}`}
-                >
-                  <FormattedMessage id="xpack.sessionView.viewRule" defaultMessage="View rule" />
-                </EuiButton>
-              </div>
-            </EuiFlexItem>
-          </EuiFlexGroup>
-          {!isLastAlert && (
-            <div>
-              <EuiHorizontalRule margin="m" />
-            </div>
-          )}
-        </EuiText>
-      );
-    });
-  }, [alerts, http.basePath]);
+export function ProcessTreeAlerts({ alerts }: ProcessTreeAlertsDeps) {
+  const styles = useStyles();
 
   if (alerts.length === 0) {
     return null;
   }
+
   return (
     <div css={styles.container} data-test-subj="sessionView:sessionViewAlertDetails">
-      {renderedAlerts}
+      {alerts.map((alert: ProcessEvent) => (
+        <ProcessTreeAlert alert={alert} />
+      ))}
     </div>
   );
 }

--- a/x-pack/plugins/session_view/public/components/process_tree_alerts/index.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree_alerts/index.tsx
@@ -5,15 +5,8 @@
  * 2.0.
  */
 
-import React, { useMemo } from 'react';
-import {
-  EuiButton,
-  EuiText,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiHorizontalRule,
-  EuiSpacer,
-} from '@elastic/eui';
+import React from 'react';
+import { EuiButton, EuiText, EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useStyles } from './styles';
 import { ProcessEvent } from '../../../common/types/process_tree';

--- a/x-pack/plugins/session_view/public/components/process_tree_alerts/styles.ts
+++ b/x-pack/plugins/session_view/public/components/process_tree_alerts/styles.ts
@@ -26,6 +26,14 @@ export const useStyles = () => {
       borderRadius: border.radius.medium,
       maxWidth: 800,
       backgroundColor: 'white',
+      '&>div': {
+        borderTop: border.thin,
+        marginTop: size.m,
+        paddingTop: size.m,
+        '&:first-child': {
+          borderTop: 'none',
+        },
+      },
     };
 
     return {

--- a/x-pack/plugins/session_view/public/components/process_tree_node/buttons.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree_node/buttons.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { EuiButton, EuiIcon, EuiToolTip } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { Process } from '../../../common/types/process_tree';
+import { useButtonStyles } from './useButtonStyles';
+
+export const ChildrenProcessesButton = ({
+  onToggle,
+  isExpanded,
+}: {
+  onToggle: () => void;
+  isExpanded: boolean;
+}) => {
+  const { button, buttonArrow, getExpandedIcon } = useButtonStyles();
+
+  return (
+    <EuiButton
+      key="child-processes-button"
+      css={button}
+      onClick={onToggle}
+      data-test-subj="sessionView:processTreeNodeChildProcessesButton"
+    >
+      <FormattedMessage id="xpack.sessionView.childProcesses" defaultMessage="Child processes" />
+      <EuiIcon css={buttonArrow} size="s" type={getExpandedIcon(isExpanded)} />
+    </EuiButton>
+  );
+};
+
+export const SessionLeaderButton = ({
+  process,
+  onClick,
+  showGroupLeadersOnly,
+}: {
+  process: Process;
+  onClick: () => void;
+  showGroupLeadersOnly: boolean;
+}) => {
+  const groupLeaderCount = process.getChildren(false).length;
+  const childCount = process.getChildren(true).length;
+  const sameGroupCount = childCount - groupLeaderCount;
+  const { button, buttonArrow, getExpandedIcon } = useButtonStyles();
+
+  if (sameGroupCount > 0) {
+    return (
+      <EuiToolTip
+        key="samePgidTooltip"
+        position="top"
+        content={
+          <p>
+            <FormattedMessage
+              id="xpack.sessionView.groupLeaderTooltip"
+              defaultMessage="Hide or show other processes in the same 'process group' (pgid) as the session leader. This typically includes forks from bash builtins, auto completions and other shell startup activity."
+            />
+          </p>
+        }
+      >
+        <EuiButton
+          key="group-leaders-only-button"
+          css={button}
+          onClick={onClick}
+          data-test-subj="sessionView:processTreeNodeChildProcessesButton"
+        >
+          <FormattedMessage
+            id="xpack.sessionView.plusCountMore"
+            defaultMessage="+{count} more"
+            values={{
+              count: sameGroupCount,
+            }}
+          />
+          <EuiIcon css={buttonArrow} size="s" type={getExpandedIcon(showGroupLeadersOnly)} />
+        </EuiButton>
+      </EuiToolTip>
+    );
+  }
+  return null;
+};
+
+export const AlertButton = ({
+  isExpanded,
+  onToggle,
+}: {
+  isExpanded: boolean;
+  onToggle: () => void;
+}) => {
+  const { alertButton, buttonArrow, getExpandedIcon } = useButtonStyles();
+
+  return (
+    <EuiButton
+      key="alert-button"
+      css={alertButton}
+      onClick={onToggle}
+      data-test-subj="processTreeNodeAlertButton"
+    >
+      <FormattedMessage id="xpack.sessionView.alerts" defaultMessage="Alerts" />
+      <EuiIcon css={buttonArrow} size="s" type={getExpandedIcon(isExpanded)} />
+    </EuiButton>
+  );
+};

--- a/x-pack/plugins/session_view/public/components/process_tree_node/buttons.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree_node/buttons.tsx
@@ -36,13 +36,14 @@ export const SessionLeaderButton = ({
   process,
   onClick,
   showGroupLeadersOnly,
+  childCount,
 }: {
   process: Process;
   onClick: () => void;
   showGroupLeadersOnly: boolean;
+  childCount: number;
 }) => {
   const groupLeaderCount = process.getChildren(false).length;
-  const childCount = process.getChildren(true).length;
   const sameGroupCount = childCount - groupLeaderCount;
   const { button, buttonArrow, getExpandedIcon } = useButtonStyles();
 

--- a/x-pack/plugins/session_view/public/components/process_tree_node/index.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree_node/index.tsx
@@ -148,6 +148,12 @@ export function ProcessTreeNode({
               <EuiIcon type={sessionIcon} /> <b css={styles.darkText}>{name || args[0]}</b>{' '}
               <FormattedMessage id="xpack.sessionView.startedBy" defaultMessage="started by" />{' '}
               <EuiIcon type="user" /> <b css={styles.darkText}>{user.name}</b>
+              <SessionLeaderButton
+                process={process}
+                childCount={childCount}
+                onClick={onShowGroupLeaderOnlyClick}
+                showGroupLeadersOnly={showGroupLeadersOnly}
+              />
             </>
           ) : (
             <span>
@@ -176,14 +182,6 @@ export function ProcessTreeNode({
                 defaultMessage="Root escalation"
               />
             </EuiButton>
-          )}
-          {isSessionLeader && (
-            <SessionLeaderButton
-              process={process}
-              childCount={childCount}
-              onClick={onShowGroupLeaderOnlyClick}
-              showGroupLeadersOnly={showGroupLeadersOnly}
-            />
           )}
           {!isSessionLeader && childCount > 0 && (
             <ChildrenProcessesButton isExpanded={childrenExpanded} onToggle={onChildrenToggle} />

--- a/x-pack/plugins/session_view/public/components/process_tree_node/index.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree_node/index.tsx
@@ -180,6 +180,7 @@ export function ProcessTreeNode({
           {isSessionLeader && (
             <SessionLeaderButton
               process={process}
+              childCount={childCount}
               onClick={onShowGroupLeaderOnlyClick}
               showGroupLeadersOnly={showGroupLeadersOnly}
             />

--- a/x-pack/plugins/session_view/public/components/process_tree_node/index.tsx
+++ b/x-pack/plugins/session_view/public/components/process_tree_node/index.tsx
@@ -19,12 +19,13 @@ import React, {
   MouseEvent,
   useCallback,
 } from 'react';
-import { EuiButton, EuiIcon, EuiToolTip } from '@elastic/eui';
+import { EuiButton, EuiIcon } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { Process } from '../../../common/types/process_tree';
-import { useStyles, ButtonType } from './styles';
+import { useStyles } from './styles';
 import { ProcessTreeAlerts } from '../process_tree_alerts';
-
+import { SessionLeaderButton, AlertButton, ChildrenProcessesButton } from './buttons';
+import { useButtonStyles } from './useButtonStyles';
 interface ProcessDeps {
   process: Process;
   isSessionLeader?: boolean;
@@ -54,6 +55,7 @@ export function ProcessTreeNode({
 
   const alerts = process.getAlerts();
   const styles = useStyles({ depth, hasAlerts: !!alerts.length });
+  const buttonStyles = useButtonStyles();
 
   useLayoutEffect(() => {
     if (searchMatched !== null && textRef.current) {
@@ -75,106 +77,13 @@ export function ProcessTreeNode({
     setShowGroupLeadersOnly(!showGroupLeadersOnly);
   }, [showGroupLeadersOnly]);
 
-  const toggleChildren = useCallback(() => {
+  const onChildrenToggle = useCallback(() => {
     setChildrenExpanded(!childrenExpanded);
   }, [childrenExpanded]);
 
-  const toggleAlerts = useCallback(() => {
+  const onAlertsToggle = useCallback(() => {
     setAlertsExpanded(!alertsExpanded);
   }, [alertsExpanded]);
-
-  const getExpandedIcon = (expanded: boolean) => {
-    return expanded ? 'arrowUp' : 'arrowDown';
-  };
-
-  const renderButtons = useCallback(() => {
-    const buttons = [];
-    const childCount = process.getChildren(true).length;
-
-    if (isSessionLeader) {
-      const groupLeaderCount = process.getChildren(false).length;
-      const sameGroupCount = childCount - groupLeaderCount;
-
-      if (sameGroupCount > 0) {
-        buttons.push(
-          <EuiToolTip
-            key="samePgidTooltip"
-            position="top"
-            content={
-              <p>
-                <FormattedMessage
-                  id="xpack.sessionView.groupLeaderTooltip"
-                  defaultMessage="Hide or show other processes in the same 'process group' (pgid) as the session leader. This typically includes forks from bash builtins, auto completions and other shell startup activity."
-                />
-              </p>
-            }
-          >
-            <EuiButton
-              key="group-leaders-only-button"
-              css={styles.getButtonStyle(ButtonType.children)}
-              onClick={onShowGroupLeaderOnlyClick}
-              data-test-subj="sessionView:processTreeNodeChildProcessesButton"
-            >
-              <FormattedMessage
-                id="xpack.sessionView.plusCountMore"
-                defaultMessage="+{count} more"
-                values={{
-                  count: sameGroupCount,
-                }}
-              />
-              <EuiIcon
-                css={styles.buttonArrow}
-                size="s"
-                type={getExpandedIcon(showGroupLeadersOnly)}
-              />
-            </EuiButton>
-          </EuiToolTip>
-        );
-      }
-    } else if (childCount > 0) {
-      buttons.push(
-        <EuiButton
-          key="child-processes-button"
-          css={styles.getButtonStyle(ButtonType.children)}
-          onClick={toggleChildren}
-          data-test-subj="sessionView:processTreeNodeChildProcessesButton"
-        >
-          <FormattedMessage
-            id="xpack.sessionView.childProcesses"
-            defaultMessage="Child processes"
-          />
-          <EuiIcon css={styles.buttonArrow} size="s" type={getExpandedIcon(childrenExpanded)} />
-        </EuiButton>
-      );
-    }
-
-    if (alerts.length) {
-      buttons.push(
-        <EuiButton
-          key="alert-button"
-          css={styles.getButtonStyle(ButtonType.alerts)}
-          onClick={toggleAlerts}
-          data-test-subj="processTreeNodeAlertButton"
-        >
-          <FormattedMessage id="xpack.sessionView.alerts" defaultMessage="Alerts" />
-          <EuiIcon css={styles.buttonArrow} size="s" type={getExpandedIcon(alertsExpanded)} />
-        </EuiButton>
-      );
-    }
-
-    return buttons;
-  }, [
-    process,
-    showGroupLeadersOnly,
-    styles,
-    alerts.length,
-    alertsExpanded,
-    childrenExpanded,
-    isSessionLeader,
-    onShowGroupLeaderOnlyClick,
-    toggleAlerts,
-    toggleChildren,
-  ]);
 
   const onProcessClicked = (e: MouseEvent) => {
     e.stopPropagation();
@@ -207,6 +116,7 @@ export function ProcessTreeNode({
   } = processDetails.process;
 
   const children = process.getChildren(!showGroupLeadersOnly);
+  const childCount = process.getChildren(true).length;
   const shouldRenderChildren = childrenExpanded && children && children.length > 0;
   const childrenTreeDepth = depth + 1;
 
@@ -259,7 +169,7 @@ export function ProcessTreeNode({
           {showRootEscalation && (
             <EuiButton
               data-test-subj="sessionView:processTreeNodeRootEscalationFlag"
-              css={styles.getButtonStyle(ButtonType.userChanged)}
+              css={buttonStyles.userChangedButton}
             >
               <FormattedMessage
                 id="xpack.sessionView.execUserChange"
@@ -267,8 +177,19 @@ export function ProcessTreeNode({
               />
             </EuiButton>
           )}
-
-          {renderButtons()}
+          {isSessionLeader && (
+            <SessionLeaderButton
+              process={process}
+              onClick={onShowGroupLeaderOnlyClick}
+              showGroupLeadersOnly={showGroupLeadersOnly}
+            />
+          )}
+          {!isSessionLeader && childCount > 0 && (
+            <ChildrenProcessesButton isExpanded={childrenExpanded} onToggle={onChildrenToggle} />
+          )}
+          {alerts.length > 0 && (
+            <AlertButton onToggle={onAlertsToggle} isExpanded={alertsExpanded} />
+          )}
         </div>
       </div>
 

--- a/x-pack/plugins/session_view/public/components/process_tree_node/styles.ts
+++ b/x-pack/plugins/session_view/public/components/process_tree_node/styles.ts
@@ -7,7 +7,6 @@
 
 import { useMemo } from 'react';
 import { useEuiTheme, transparentize } from '@elastic/eui';
-import { euiLightVars as theme } from '@kbn/ui-theme';
 import { CSSObject } from '@emotion/react';
 
 interface StylesDeps {
@@ -15,18 +14,11 @@ interface StylesDeps {
   hasAlerts: boolean;
 }
 
-export const enum ButtonType {
-  children = 'children',
-  alerts = 'alerts',
-  output = 'output',
-  userChanged = 'user',
-}
-
 export const useStyles = ({ depth, hasAlerts }: StylesDeps) => {
   const { euiTheme } = useEuiTheme();
 
   const cached = useMemo(() => {
-    const { colors, border, font, size } = euiTheme;
+    const { colors, border, size } = euiTheme;
 
     const TREE_INDENT = euiTheme.base * 2;
 
@@ -47,44 +39,6 @@ export const useStyles = ({ depth, hasAlerts }: StylesDeps) => {
       paddingLeft: size.s,
       borderLeft: border.editable,
       marginTop: size.s,
-    };
-
-    const button: CSSObject = {
-      lineHeight: '18px',
-      height: '20px',
-      fontSize: '11px',
-      fontFamily: font.familyCode,
-      borderRadius: border.radius.medium,
-      color: colors.text,
-      marginLeft: size.s,
-      minWidth: 0,
-    };
-
-    const buttonArrow: CSSObject = {
-      marginLeft: size.s,
-    };
-
-    const getButtonStyle = (type: string): CSSObject => {
-      let background = transparentize(theme.euiColorVis6, 0.04);
-      let borderStyle = `${border.width.thin} solid ${transparentize(theme.euiColorVis6, 0.48)}`;
-
-      switch (type) {
-        case ButtonType.alerts:
-          background = transparentize(colors.dangerText, 0.04);
-          borderStyle = `${border.width.thin} solid ${transparentize(colors.dangerText, 0.48)}`;
-          break;
-        case ButtonType.userChanged:
-        case ButtonType.output:
-          background = transparentize(theme.euiColorVis1, 0.04);
-          borderStyle = `${border.width.thin} solid ${transparentize(theme.euiColorVis1, 0.48)}`;
-          break;
-      }
-
-      return {
-        ...button,
-        background,
-        border: borderStyle,
-      };
     };
 
     /**
@@ -156,8 +110,6 @@ export const useStyles = ({ depth, hasAlerts }: StylesDeps) => {
       processNode,
       wrapper,
       workingDir,
-      buttonArrow,
-      getButtonStyle,
       alertDetails,
     };
   }, [depth, euiTheme, hasAlerts]);

--- a/x-pack/plugins/session_view/public/components/process_tree_node/useButtonStyles.ts
+++ b/x-pack/plugins/session_view/public/components/process_tree_node/useButtonStyles.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import { useEuiTheme, transparentize } from '@elastic/eui';
+import { euiLightVars as theme } from '@kbn/ui-theme';
+import { CSSObject } from '@emotion/react';
+
+export const useButtonStyles = () => {
+  const { euiTheme } = useEuiTheme();
+
+  const cached = useMemo(() => {
+    const { colors, border, font, size } = euiTheme;
+
+    const button: CSSObject = {
+      background: transparentize(theme.euiColorVis6, 0.04),
+      border: `${border.width.thin} solid ${transparentize(theme.euiColorVis6, 0.48)}`,
+      lineHeight: '18px',
+      height: '20px',
+      fontSize: '11px',
+      fontFamily: font.familyCode,
+      borderRadius: border.radius.medium,
+      color: colors.text,
+      marginLeft: size.s,
+      minWidth: 0,
+    };
+
+    const buttonArrow: CSSObject = {
+      marginLeft: size.s,
+    };
+
+    const alertButton: CSSObject = {
+      ...button,
+      background: transparentize(colors.dangerText, 0.04),
+      border: `${border.width.thin} solid ${transparentize(colors.dangerText, 0.48)}`,
+    };
+
+    const userChangedButton: CSSObject = {
+      ...button,
+      background: transparentize(theme.euiColorVis1, 0.04),
+      border: `${border.width.thin} solid ${transparentize(theme.euiColorVis1, 0.48)}`,
+    };
+
+    const getExpandedIcon = (expanded: boolean) => {
+      return expanded ? 'arrowUp' : 'arrowDown';
+    };
+
+    return {
+      buttonArrow,
+      button,
+      alertButton,
+      userChangedButton,
+      getExpandedIcon,
+    };
+  }, [euiTheme]);
+
+  return cached;
+};


### PR DESCRIPTION
## Summary

As pointed out by [Kevin Qualters](https://github.com/elastic/kibana/pull/124575#discussion_r816439048) some methods make more sense if split into their own separate components. 

- This PR converts the` renderButtons()` and `renderedAlerts()` method into components, it was the lasts ones left using the call render function pattern,
- removes the output button, since we won't have it for the targeted version and bring buttons styles directly instead of having a getter style function

Worth noting that is not always that render functions should be avoided ([Reference](https://dev.to/igor_bykov/react-calling-functional-components-as-functions-1d3l)), but in the case of `renderButtons` and `renderedAlerts()` it makes sense because it opens room for further improvements + we'll get in sync with the already adopted pattern 